### PR TITLE
Create WARNING_PATTERN regex to catch warnings

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -21,7 +21,8 @@ from buildbot.schedulers.forcesched import (ForceScheduler, FixedParameter,
                                             StringParameter, UserNameParameter)
 from buildbot.process import factory
 from buildbot.status import html, mail, words
-from buildbot.steps.shell import ShellCommand, Configure, Test, Compile
+from buildbot.steps.shell import (ShellCommand, Configure, Compile,
+                                  Test as BaseTest)
 from buildbot.steps.transfer import DirectoryUpload
 from buildbot import util, locks
 from buildbot.steps.source.git import Git
@@ -86,6 +87,22 @@ UNSTABLE = ".unstable"
 # It is a bit more than the default faulthandler timeout in regrtest.py
 # (the latter isn't easily changed under Windows).
 TEST_TIMEOUT = 20 * 60
+
+
+class Test(BaseTest):
+    # Regular expression used to catch warnings, errors and bugs
+    warningPattern = "(?:%s)" % "|".join((
+        # regrtest saved_test_environment warning:
+        # Warning -- files was modified by test_distutils
+        "^Warning --",
+        # Py_FatalError() call
+        "^Fatal Python error:",
+        # Resource warning: unclosed file, socket, etc.
+        "ResourceWarning",
+        # PyErr_WriteUnraisable() exception: usually, error in
+        # garbage collector or destructor
+        "Exception ignored in:",
+    ))
 
 
 class Clean(ShellCommand):


### PR DESCRIPTION
Define a regular expression to catch different warnings, errors and
bugs specific to CPython.