### PR TITLE
warningPattern: add Windows fatal exception

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -11,6 +11,7 @@
 # buildmaster. They are documented in docs/config.xhtml .
 
 import os
+import re
 import sys
 
 from twisted.python import log
@@ -94,15 +95,21 @@ class Test(BaseTest):
     warningPattern = "(?:%s)" % "|".join((
         # regrtest saved_test_environment warning:
         # Warning -- files was modified by test_distutils
-        "^Warning --",
+        r"Warning --",
         # Py_FatalError() call
-        "^Fatal Python error:",
-        # Resource warning: unclosed file, socket, etc.
-        "ResourceWarning",
+        r"Fatal Python error:",
         # PyErr_WriteUnraisable() exception: usually, error in
         # garbage collector or destructor
-        "Exception ignored in:",
+        r"Exception ignored in:",
+        # faulthandler_exc_handler(): Windows exception handler installed with
+        # AddVectoredExceptionHandler() by faulthandler.enable()
+        r"Windows fatal exception:",
+        # Resource warning: unclosed file, socket, etc.
+        # NOTE: match the "ResourceWarning" anywhere, not only at the start
+        r".*ResourceWarning",
     ))
+    # The log consumer calls warningPattern.match(line)
+    warningPattern = re.compile(warningPattern)
 
 
 class Clean(ShellCommand):


### PR DESCRIPTION
* Fix also the regex for ResourceWarning: need ".*" prefix, since
  .match() is used, not .search()
* Compile warningPattern regex once