### PR TITLE
Adjust builder timeouts

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -92,8 +92,9 @@ TEST_TIMEOUT = 20 * 60
 
 class FreezeBuild(factory.BuildFactory):
     buildersuffix = '.freeze'  # to get unique directory names on master
+    test_timeout = None
 
-    def __init__(self, source, parallel, test_timeout=None, branch=None):
+    def __init__(self, source, parallel, branch=None):
         factory.BuildFactory.__init__(self, [source])
         self.addStep(Configure(command=[
             './configure', '--prefix', '$(PWD)/target']))
@@ -112,8 +113,9 @@ class UnixBuild(factory.BuildFactory):
     interpreterFlags = ""
     testFlags = "-j2"
     makeTarget = "all"
+    test_timeout = None
 
-    def __init__(self, source, parallel, test_timeout=None, branch=None,
+    def __init__(self, source, parallel, branch=None,
                  test_with_PTY='slave-config'):
         factory.BuildFactory.__init__(self, [source])
         self.addStep(Configure(command=['./configure'] + self.configureFlags))
@@ -123,9 +125,9 @@ class UnixBuild(factory.BuildFactory):
         if '-j' not in testopts:
             testopts = '-j2 ' + testopts
         # Timeout for the buildslave process
-        test_timeout = test_timeout or TEST_TIMEOUT
+        self.test_timeout = self.test_timeout or TEST_TIMEOUT
         # Timeout for faulthandler
-        faulthandler_timeout = test_timeout - 5 * 60
+        faulthandler_timeout = self.test_timeout - 5 * 60
         if parallel:
             compile = ['make', parallel, self.makeTarget]
             testopts = testopts + ' ' + parallel
@@ -135,13 +137,17 @@ class UnixBuild(factory.BuildFactory):
 
         self.addStep(Compile(command=compile))
         self.addStep(Test(
-            command=test, timeout=test_timeout, usePTY=test_with_PTY))
+            command=test, timeout=self.test_timeout, usePTY=test_with_PTY))
         self.addStep(Clean())
 
 
 class UnixRefleakBuild(UnixBuild):
     buildersuffix = '.refleak'
     testFlags = "-R 3:3:refleaks.log"
+    # -R 3:3 is supposed to only require timeout x 6, but in practice,
+    # it's much more slower. Use timeout x 10 to prevent timeout
+    # caused by --huntrleaks.
+    test_timeout = TEST_TIMEOUT * 10
 
 
 class UnixInstalledBuild(factory.BuildFactory):
@@ -151,8 +157,9 @@ class UnixInstalledBuild(factory.BuildFactory):
     defaultTestOpts = ['-rwW', '-uall', '-j2']
     makeTarget = "all"
     installTarget = "install"
+    test_timeout = None
 
-    def __init__(self, source, parallel, branch, test_timeout=None,
+    def __init__(self, source, parallel, branch,
                  test_with_PTY='slave-config'):
         factory.BuildFactory.__init__(self, [source])
         if branch == '3.x':
@@ -166,7 +173,7 @@ class UnixInstalledBuild(factory.BuildFactory):
         install = ['make', self.installTarget]
         testopts = self.defaultTestOpts[:]
         # Timeout for the buildslave process
-        test_timeout = test_timeout or TEST_TIMEOUT
+        self.test_timeout = self.test_timeout or TEST_TIMEOUT
         # Timeout for faulthandler
         if parallel:
             compile = ['make', parallel, self.makeTarget]
@@ -179,7 +186,7 @@ class UnixInstalledBuild(factory.BuildFactory):
         self.addStep(Install(command=install))
         self.addStep(LockInstall())
         self.addStep(Test(
-            command=test, timeout=test_timeout, usePTY=test_with_PTY))
+            command=test, timeout=self.test_timeout, usePTY=test_with_PTY))
         self.addStep(Uninstall())
         self.addStep(Clean())
 
@@ -299,8 +306,9 @@ class WindowsBuild(factory.BuildFactory):
     buildFlags = []
     testFlags = ['-j2']
     cleanFlags = []
+    test_timeout = None
 
-    def __init__(self, source, parallel, branch=None, test_timeout=None):
+    def __init__(self, source, parallel, branch=None):
         build_command = self.build_command + self.buildFlags
         test_command = self.test_command + self.testFlags
         clean_command = self.clean_command + self.cleanFlags
@@ -309,10 +317,10 @@ class WindowsBuild(factory.BuildFactory):
         factory.BuildFactory.__init__(self, [source])
         self.addStep(Compile(command=build_command))
         # timeout is a bit more than the regrtest default timeout
-        if test_timeout:
+        if self.test_timeout:
             if branch != '2.7':
-                test_command += ['--timeout', test_timeout - (5 * 60)]
-            timeout = test_timeout
+                test_command += ['--timeout', self.test_timeout - (5 * 60)]
+            timeout = self.test_timeout
         else:
             timeout = TEST_TIMEOUT
         self.addStep(Test(command=test_command, timeout=timeout))
@@ -390,6 +398,12 @@ class DMG(factory.BuildFactory):
         )
 
 
+class TigerBuild(UnixBuild):
+    # bpo-30314: x86 Tiger requires longer than 15 minutes on some tests
+    # like test_tools
+    test_timeout = 30 * 60
+
+
 class UnixDocBuild(factory.BuildFactory):
 
     def __init__(self, source, branch):
@@ -449,7 +463,7 @@ if PRODUCTION:
         ("x86 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild, STABLE),
         # OS X
         ("AMD64 Snow Leop", "murray-snowleopard", UnixBuild, STABLE),
-        ("x86 Tiger", "bolen-tiger", UnixBuild, STABLE),
+        ("x86 Tiger", "bolen-tiger", TigerBuild, STABLE),
         # Other Unix
         ("AMD64 FreeBSD 9.x", "koobs-freebsd9", UnixBuild, STABLE),
         ("AMD64 FreeBSD 10.x Shared", "koobs-freebsd10",


### PR DESCRIPTION
* UnixRefleakBuild: use timeout x 10 since --huntrleaks makes tests
  much slower
* bpo-30314: Use 30 min rather than 20 min for x86 Tiger.