### PR TITLE
Drop a concurrent build on koobs-freebsd-current

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -539,8 +539,6 @@ cpulock = locks.SlaveLock("cpu", maxCountForSlave={
     'cea-indiana-x86': 3,
     'cea-indiana-amd64': 3,
     'kloth-win64': 2,
-    'intel-yosemite-icc': 2,
-    'koobs-freebsd-current': 2,
     'ware-gentoo-x86': 2,
 })
 


### PR DESCRIPTION
Also removes intel-yosemite-icc concurrent build; the worker is no longer there.