### PR TITLE
Remove koobs-freebsd9 (9-STABLE) builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -462,7 +462,6 @@ if PRODUCTION:
         # OS X
         ("x86 Tiger", "bolen-tiger", TigerBuild, STABLE),
         # Other Unix
-        ("AMD64 FreeBSD 9.x", "koobs-freebsd9", UnixBuild, STABLE),
         ("AMD64 FreeBSD 10.x Shared", "koobs-freebsd10",
             SharedUnixBuild, STABLE),
         ("AMD64 FreeBSD CURRENT Debug", "koobs-freebsd-current",
@@ -522,7 +521,6 @@ parallel = {
     'cea-indiana-amd64': '-j4',
     'kloth-win64': '-j4',
     # Snakebite
-    'koobs-freebsd9': '-j4',
     'koobs-freebsd10': '-j4',
     'gps-ubuntu-exynos5-armv7l': '-j8',
     'ware-win81-release': '-j4',


### PR DESCRIPTION
The releng/9.3 (latest 9.x release security branch) and stable/9 branches (the latter of which this worker run on), hit End-of-Life December 31, 2016 [1]

Accordingly, this change removes the koobs-freebsd9 builder as support for it has stopped.

[1] https://www.freebsd.org/security/unsupported.html