### PR TITLE
Remove Python 3.5 buildbots

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,7 +67,6 @@ c['slaves'] = SLAVES
 git_branches = [
     (GIT_URL, "3.x", "master"),
     (GIT_URL, "3.6", "3.6"),
-    (GIT_URL, "3.5", "3.5"),
     (GIT_URL, "2.7", "2.7"),
     (GIT_URL, "custom", "buildbot-custom"),
     # Add the following line if you want to clean up a particular
@@ -683,7 +682,6 @@ else:
     dmg_slaves = []
 
 for version, git_branch, hour in (('2.7', '2.7', 12),
-                                  ('3.5', '3.5', 13),
                                   ('3.6', '3.6', 14),
                                   ('3.x', 'master', 15),
                                   ):


### PR DESCRIPTION
Python 3.5 just entered security-fixes only:
https://mail.python.org/pipermail/python-dev/2017-August/148794.html