### PR TITLE
Drop OpenIndiana slaves

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -254,18 +254,6 @@ class SharedUnixBuild(UnixBuild):
     configureFlags = ["--with-pydebug", "--enable-shared"]
 
 
-class OpenIndianaBuild(UnixBuild):
-    configureFlags = ["--with-pydebug", "CFLAGS=-I/usr/local/include/ncursesw"]
-
-
-class OpenIndiana64Build(UnixBuild):
-    configureFlags = [
-        "--with-pydebug",
-        "CFLAGS=-I/usr/local/include/ncursesw -m64",
-        "LDFLAGS=-L/usr/local/lib/64 -m64",
-    ]
-
-
 class SolarisBuild(UnixBuild):
     # Issue #12927
     configureFlags = ["--with-pydebug", "--with-system-ffi", "--with-dtrace"]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -485,10 +485,7 @@ if PRODUCTION:
         ("x86-64 El Capitan", "billenstein-elcapitan", UnixBuild, UNSTABLE),
         ("x86-64 Sierra", "billenstein-sierra", UnixBuild, UNSTABLE),
         # Other Unix
-        ("AMD64 OpenIndiana", "cea-indiana-amd64",
-            OpenIndiana64Build, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
-        ("x86 OpenIndiana", "cea-indiana-x86", OpenIndianaBuild, UNSTABLE),
         ("x86 OpenBSD", "borja-openbsd-x86", UnixBuild, UNSTABLE),
         # Windows
         ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, UNSTABLE),
@@ -514,8 +511,6 @@ c['builders'] = []
 c['schedulers'] = []
 
 parallel = {
-    'cea-indiana-x86': '-j4',
-    'cea-indiana-amd64': '-j4',
     'kloth-win64': '-j4',
     # Snakebite
     'koobs-freebsd10': '-j4',
@@ -531,8 +526,6 @@ extra_factory_args = {
 
 # The following with the slave owners' agreement
 cpulock = locks.SlaveLock("cpu", maxCountForSlave={
-    'cea-indiana-x86': 3,
-    'cea-indiana-amd64': 3,
     'kloth-win64': 2,
     'ware-gentoo-x86': 2,
 })


### PR DESCRIPTION
The builder is offline since the beginning of June.

Previous discussions on python-dev:

* September 2016: OpenIndiana and Solaris support
  https://mail.python.org/pipermail/python-dev/2016-September/146538.html
* April 2015: MemoryError and other bugs on AMD64 OpenIndiana 3.x
  https://mail.python.org/pipermail/python-dev/2015-April/138967.html
* September 2014: Sad status of Python 3.x buildbots
  https://mail.python.org/pipermail/python-dev/2014-September/136175.html