### PR TITLE
Add the Android build factory

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -125,7 +125,7 @@ class UnixBuild(factory.BuildFactory):
     def __init__(self, source, parallel, branch=None,
                  test_with_PTY=False):
         factory.BuildFactory.__init__(self, [source])
-        self.addStep(Configure(command=['./configure'] + self.configureFlags))
+        self.add_initial_step()
 
         compile = ['make', self.makeTarget]
         testopts = self.testFlags
@@ -151,6 +151,9 @@ class UnixBuild(factory.BuildFactory):
             command=test, timeout=self.test_timeout, usePTY=test_with_PTY))
         self.addStep(Clean())
 
+    def add_initial_step(self):
+        self.addStep(Configure(command=['./configure'] + self.configureFlags))
+
 
 class UnixRefleakBuild(UnixBuild):
     buildersuffix = '.refleak'
@@ -160,6 +163,9 @@ class UnixRefleakBuild(UnixBuild):
     # caused by --huntrleaks.
     test_timeout = TEST_TIMEOUT * 10
 
+
+# XXX Update this with each release
+PYTHON_DEVPT_VERSION = '3.7'
 
 class UnixInstalledBuild(factory.BuildFactory):
     buildersuffix = ".installed"
@@ -174,8 +180,7 @@ class UnixInstalledBuild(factory.BuildFactory):
                  test_with_PTY=False):
         factory.BuildFactory.__init__(self, [source])
         if branch == '3.x':
-            # XXX Update this with each release
-            branch = '3.7'
+            branch = PYTHON_DEVPT_VERSION
         installed_python = './target/bin/python%s' % branch
         self.addStep(Configure(command=[
             './configure', '--prefix', '$(PWD)/target'] + self.configureFlags))
@@ -242,6 +247,14 @@ class AIXBuildWithGcc(UnixBuild):
 class NonDebugUnixBuild(UnixBuild):
     buildersuffix = '.nondebug'
     configureFlags = []
+
+
+class AndroidBuild(UnixBuild):
+    def add_initial_step(self):
+        self.addStep(ShellCommand(name="makesetup",
+                                  description="makesetup",
+                                  command=['bash', 'Android/makesetup'],
+                                  warnOnFailure=True))
 
 
 class QuietNonDebugUnixBuild(NonDebugUnixBuild):
@@ -541,6 +554,16 @@ def is_important_change(change):
 
 # Regular builders
 
+AndroidEnviron = {
+    # The development version is used to statically allocate port numbers to
+    # emulators. For example there is the (3.x, x86_64) emulator and the
+    # (maintenance version, x86_64) emulator.
+    'PYTHON_DEVPT_VERSION': PYTHON_DEVPT_VERSION,
+    'ANDROID_API': '24',
+    'WITH_LIBRARIES': 'libffi,ncurses,openssl,readline,sqlite',
+    'EMULATOR_CMD_LINE_OPTIONS': '-use-system-libs -no-window',
+}
+
 for git_url, branchname, git_branch in git_branches:
     buildernames = []
     dailybuildernames = []
@@ -556,6 +579,17 @@ for git_url, branchname, git_branch in git_branches:
         if name.endswith("Freeze") and branchname == "2.7":
             # 2.7 isn't set up for testing freezing
             continue
+        if issubclass(buildfactory, AndroidBuild):
+            env = dict(AndroidEnviron)
+            for word in name.split():
+                if word in ('x86', 'x86_64', 'armv7', 'arm64'):
+                    env['ANDROID_ARCH'] = word
+                    break
+            else:
+                assert False, 'Android architecture is not defined'
+        else:
+            env = {}
+
         buildername = name + " " + branchname
         source = Git(repourl=git_url, branch=git_branch, timeout=3600)
         p = parallel.get(worker)
@@ -578,7 +612,8 @@ for git_url, branchname, git_branch in git_branches:
                 ),
                 factory=f,
                 tags=[branchname + stability],
-                locks=[cpulock.access('counting')]
+                locks=[cpulock.access('counting')],
+                env=env,
             )
         )
     # Make sure daily builders pick up custom jobs, and don't try to run when


### PR DESCRIPTION
The Python test suite succeeds when run with buildbot strenuous settings with all the Android architectures on API 24: x86, x86_64, armv7 and arm64.

This PR proposes to update ``master.cfg`` to run buildbots for Android.  The Android build system is implemented at issue [bpo-30386](https://bugs.python.org/issue30386) and [PR 1629](https://github.com/python/cpython/pull/1629), it adds the ``Android/`` directory and the ``configure-android`` script to the root of the source directory without modifying any other file. The build system can be installed, upgraded (i.e. the SDK and NDK) and run remotely, through ssh for example.

The Android emulator is actually ``qemu``, so the test suites for x86 and x86_64 last about the same time as the test suite run natively when the processor of the build system is of the x86 family.  The test suites for the arm architectures last much longer: about 8 hours for arm64 and 10 hours for armv7 on a four years old laptop when the test suite is run with ``-u all -j1``. Since none of the changes to Python that have been made for Android is specific to armv7 or arm64, maybe their test suite could be run just weekly.

The ``buildbot.sh`` script simulates the operations executed by a buildbot worker (except for the git step) and explains the changes to ``master.cfg`` proposed here. Its content is listed here:

    #! /bin/bash
    # Run the commands triggered by a Python buildbot master.

    # makesetup step
    PYTHON_DEVPT_VERSION=3.7 \
        WITH_LIBRARIES=libffi,ncurses,openssl,readline,sqlite \
        EMULATOR_CMD_LINE_OPTIONS="-use-system-libs -no-window" \
        ANDROID_API=24 \
        ANDROID_ARCH=x86_64 \
        Android/makesetup --with-pydebug > makesetup.log 2>&1
    echo "makesetup step done with exit status: $?"

    # compile step
    make all > compile.log 2>&1
    echo "compile step done with exit status: $?"

    # pythoninfo step
    make pythoninfo > pythoninfo.log 2>&1
    echo "pythoninfo step done with exit status: $?"

    # test step
    make buildbottest TESTOPTS=-j2 TESTPYTHONOPTS= TESTTIMEOUT=900 > test.log 2>&1
    echo "test step done with exit status: $?"

    # clean step
    make distclean > clean.log 2>&1
    echo "clean step done with exit status: $?"

Running this script on x86_64 gives the following results (the corresponding five log files are attached in the next comment) when it is run the second time, on the first run the native python and the external libraries are built and compile.log contains a lot more lines:

    $ /path/to/buildbot.sh
    makesetup step done with exit status: 0
    compile step done with exit status: 0
    pythoninfo step done with exit status: 0
    test step done with exit status: 0
    clean step done with exit status: 0


