### PR TITLE
Add Cygwin builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -146,9 +146,13 @@ class UnixBuild(TaggedBuildFactory):
             testopts = testopts + ' ' + parallel
         if '-j' not in testopts:
             testopts = '-j2 ' + testopts
-        test = ["make", "buildbottest", "TESTOPTS=" + testopts]
-        test += ["TESTPYTHONOPTS=" + self.interpreterFlags]
-        test += ["TESTTIMEOUT=" + str(faulthandler_timeout)]
+        test = [
+            "make",
+            "buildbottest",
+            "TESTOPTS=" + testopts + " ${BUILDBOT_TESTOPTS}",
+            "TESTPYTHONOPTS=" + self.interpreterFlags,
+            "TESTTIMEOUT=" + str(faulthandler_timeout),
+        ]
 
         self.addStep(Compile(command=compile))
         self.addStep(ShellCommand(name="pythoninfo",
@@ -484,6 +488,7 @@ if PRODUCTION:
         # Linux other archs
         # macOS
         # Other Unix
+        ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
         ("POWER6 AIX", "aixtools-aix-power6", AIXBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
         # Windows
@@ -565,6 +570,9 @@ for git_url, branchname, git_branch in git_branches:
     for name, worker, buildfactory, stability in builders:
         if "Windows XP" in name and branchname != "2.7":
             # 3.5+ drop support for XP
+            continue
+        if "Cygwin" in name and branchname in ("3.6", "3.7", "2.7"):
+            # Cygwin is not supported on these branches.
             continue
         if "VS9.0" in name and branchname != "2.7":
             continue


### PR DESCRIPTION
This also allows buildbot owners to set BUILDBOT_TESTOPTS to add options to regrtest.

@vstinner I'd like your OK before merging this, particularly on the addition of `BUILDBOT_TESTOPTS`.

cc @embray