### PR TITLE
Add POWER6 AIX builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -484,6 +484,7 @@ if PRODUCTION:
         # Linux other archs
         # macOS
         # Other Unix
+        ("POWER6 AIX", "aixtools-aix-power6", AIXBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
         # Windows
     ]


### PR DESCRIPTION
Pending confirmation from @aixtools that the options in `AIXBuild` are good and don't need to be changed.