### PR TITLE
Modify AIX bots to use less optimized OpenSSL library

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -232,13 +232,17 @@ class UnixBuildWithoutDocStrings(UnixBuild):
 class AIXBuild(UnixBuild):
     configureFlags = [
         "--with-pydebug",
-        "--without-gcc",
-        "--without-computed-gotos",
+        "--with-openssl=/opt/aixtools",
+        "--without-computed-gotos"
     ]
 
 
 class AIXBuildWithGcc(UnixBuild):
-    configureFlags = ["--with-pydebug", "--with-gcc=yes"]
+    configureFlags = [
+        "--with-pydebug",
+        "--with-openssl=/opt/aixtools",
+        "--with-gcc=yes"
+    ]
 
 
 class NonDebugUnixBuild(UnixBuild):


### PR DESCRIPTION
as the highly optimized openssl supplied by IBM does not always
report the error message, only that an error has occurred.

After I built this library from OpenSSL sources and manually tested python for AIX linked against it all the ssl.py and _ssl.c dependent tests pass.

While this is not the library that I expect to be used in production it does demonstrate that AIX is stable with regard to OpenSSL (tests).