### PR TITLE
Add Authz configuration

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -53,6 +53,41 @@ except ImportError:
     GIT_URL = 'https://github.com/python/cpython.git'
     GITHUB_SECRET = 'thisisntverysecret'
 
+if PRODUCTION:
+    AUTHZ = util.Authz(
+        allowRules=[
+            # Admins can do anything.
+            util.AnyEndpointMatcher(role="admins", defaultDeny=False),
+            # Allow authors to stop or rebuild their own builds, allow core
+            # devs to stop or rebuild any build.
+            util.StopBuildEndpointMatcher(role="owner", defaultDeny=False),
+            util.StopBuildEndpointMatcher(role="python-core"),
+            util.RebuildBuildEndpointMatcher(role="owner", defaultDeny=False),
+            util.RebuildBuildEndpointMatcher(role="python-core"),
+            # Allow release managers to enable/disable schedulers.
+            util.EnableSchedulerEndpointMatcher(role="python-release-managers"),
+            # Future-proof control endpoints.
+            util.AnyControlEndpointMatcher(role="admins"),
+        ],
+        roleMatchers=[
+            util.RolesFromGroups(groupPrefix='python/'),
+            util.RolesFromOwner(role="owner"),
+            util.RolesFromUsername(
+                roles=['admins'],
+                usernames=[
+                    'zware',
+                    'vstinner',
+                    'bitdancer',
+                    'pitrou',
+                    'pablogsal',
+                ],
+            )
+        ]
+    )
+else:
+    # Default to open.
+    AUTHZ = util.Authz()
+
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
 c = BuildmasterConfig = {}
@@ -718,6 +753,7 @@ c['protocols'] = {
 c['www'] = dict(
     port=WEB_PORT,
     auth=AUTH,
+    authz=AUTHZ,
     change_hook_dialects={
         'github': {'secret': GITHUB_SECRET, 'strict': True},
     },


### PR DESCRIPTION
Relevant documentation can be found [here](http://docs.buildbot.net/latest/manual/cfg-www.html#authz-configuration),
but mostly I'm looking for a review of the semantics proposed in the comments.
I think the code will actually do that, but we'll find out when we start trying
to use it :)