### PR TITLE
Standardize FreeBSD worker configuration

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -505,12 +505,10 @@ if PRODUCTION:
         ("x86-64 El Capitan", "billenstein-elcapitan", UnixBuild, STABLE),
         ("x86-64 High Sierra", "billenstein-sierra", UnixBuild, STABLE),
         # Other Unix
-        ("AMD64 FreeBSD 10.x Shared", "koobs-freebsd10",
-            SharedUnixBuild, STABLE),
-        ("AMD64 FreeBSD CURRENT Debug", "koobs-freebsd-current",
-            UnixBuild, STABLE),
-        ("AMD64 FreeBSD CURRENT Non-Debug", "koobs-freebsd-current",
+        ("AMD64 FreeBSD 10-STABLE Non-Debug", "koobs-freebsd10",
             NonDebugUnixBuild, STABLE),
+        ("AMD64 FreeBSD CURRENT Shared", "koobs-freebsd-current",
+            SharedUnixBuild, STABLE),
         # Windows
         ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, STABLE),
         ("AMD64 Windows7 SP1 VS9.0", "kloth-win64",
@@ -558,6 +556,7 @@ parallel = {
     'kloth-win64': '-j4',
     # Snakebite
     'koobs-freebsd10': '-j4',
+    'koobs-freebsd-current': '-j4',
     'gps-ubuntu-exynos5-armv7l': '-j8',
     'ware-win81-release': '-j4',
 }


### PR DESCRIPTION
Remove one builder from the freebsd-current worker. There's not a sufficient
amount of value in testing both debug and non-debug builds on the same worker,
particularly since only one (buildbot) build is allowed to run at a time, so
they end up queued and run sequentially.

While I'm here:

Switch the freebsd-current worker to the 'SharedUnixBuild', because it also
builds with --with-debug and @vstinner says debug is likely to be more valuable
on bleeding edge OS versions. Accordingly, switch freebsd10 worker to the
'NonDebugUnixBuild'.

Set -j4 on freebsd-current worker to match freebsd10 worker for in-test
parallism, allowing the worker owner to (somewhat) manage parallelism/load
themselves via guest CPU configuration.

Update the freebsd10 worker description to use the canonical branch label/term: STABLE, not ".x".