### PR TITLE
Add force scheduler

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -16,6 +16,7 @@ import sys
 from datetime import timedelta
 
 from buildbot.schedulers.basic import SingleBranchScheduler
+from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.plugins import reporters, util
 from buildbot.process import factory
@@ -62,12 +63,14 @@ if PRODUCTION:
         allowRules=[
             # Admins can do anything.
             util.AnyEndpointMatcher(role="admins", defaultDeny=False),
-            # Allow authors to stop or rebuild their own builds, allow core
-            # devs to stop or rebuild any build.
+            # Allow authors to stop, force or rebuild their own builds,
+            # allow core devs to stop, force or rebuild any build.
             util.StopBuildEndpointMatcher(role="owner", defaultDeny=False),
             util.StopBuildEndpointMatcher(role="python-core"),
             util.RebuildBuildEndpointMatcher(role="owner", defaultDeny=False),
             util.RebuildBuildEndpointMatcher(role="python-core"),
+            util.ForceBuildEndpointMatcher(role="owner", defaultDeny=False),
+            util.ForceBuildEndpointMatcher(role="python-core"),
             # Allow release managers to enable/disable schedulers.
             util.EnableSchedulerEndpointMatcher(role="python-release-managers"),
             # Future-proof control endpoints.
@@ -731,6 +734,29 @@ for version, git_branch, hour in (('2.7', '2.7', 12),
             change_filter=util.ChangeFilter(branch=git_branch),
         ))
 
+
+# Set up aditional schedulers
+
+c["schedulers"].append(
+    ForceScheduler(
+        name="force",
+        builderNames=[builder.name for builder in c["builders"]],
+        reason=util.FixedParameter(name="reason", label="reason", default=""),
+        codebases=[
+            util.CodebaseParameter(
+                "",
+                label="CPython repository",
+                # will generate nothing in the form, but branch, revision, repository,
+                # and project are needed by buildbot scheduling system so we
+                # need to pass a value ("")
+                branch=util.FixedParameter(name="branch", default=""),
+                revision=util.FixedParameter(name="revision", default=""),
+                repository=util.FixedParameter(name="repository", default=""),
+                project=util.FixedParameter(name="project", default=""),
+            ),
+        ],
+    )
+)
 
 # 'workerPortnum' defines the TCP port to listen on. This must match the value
 # configured into the buildworkers (with their --master option)


### PR DESCRIPTION
This Pull Request adds a new scheduler that will allow users to force the build of different branches for a particular builder.

(The ability for allowing other repositories will be done in a separate PR).

Closes #52