### PR TITLE
Only notify failures by email for stable builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -319,9 +319,8 @@ for git_url, branchname, git_branch in git_branches:
             dailybuildernames.append(buildername)
         else:
             buildernames.append(buildername)
-        if branchname != 'custom':
-            mail_status_builders.append(buildername)
         if stability == STABLE:
+            mail_status_builders.append(buildername)
             github_status_builders.append(buildername)
         c['builders'].append(
             util.BuilderConfig(


### PR DESCRIPTION
Some builders are sending email notifications but they are fundamentally broken. An example of this is the AMD64 Cygwin64 on Windows 10 3.x:

https://buildbot.python.org/all/#/builders/164

As we already have a lot of noise due to random failures, minimizing the ammount of email we need to check is important.