### PR TITLE
GH-68: git clone failures mark the build as WARNING

### DIFF
--- a/master/custom/steps.py
+++ b/master/custom/steps.py
@@ -1,6 +1,15 @@
 import re
 
 from buildbot.steps.shell import ShellCommand, Test as BaseTest
+from buildbot.steps.source.git import Git as _Git
+
+
+class Git(_Git):
+    # GH-68: If "git clone" fails, mark the whole build as WARNING
+    # (warnOnFailure), not as "FAILURE" (flunkOnFailure)
+    haltOnFailure = True
+    flunkOnFailure = False
+    warnOnFailure = True
 
 
 class Test(BaseTest):
@@ -44,7 +53,7 @@ class Test(BaseTest):
 
     # if tests have warnings, mark the overall build as WARNINGS (orange)
     warnOnWarnings = True
-    
+
     # 3 hours should be enough even for refleak builds.
     maxTime = 3 * 60 * 60
     # Give SIGTERM 30 seconds to shut things down before SIGKILL.

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -20,7 +20,6 @@ from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.plugins import reporters, util
 from buildbot import locks
-from buildbot.steps.source.git import Git
 
 sys.path.append(os.path.dirname(__file__))   # noqa: E402
 
@@ -47,6 +46,7 @@ from custom.factories import (
     Windows64ReleaseBuild,
 )
 from custom.pr_reporter import GitHubPullRequestReporter
+from custom.steps import Git
 
 # sensitive and/or instance-specific values
 try:


### PR DESCRIPTION
If "git clone" fails, mark the whole build as WARNING
(warnOnFailure), not as "FAILURE" (flunkOnFailure).