### PR TITLE
Do not fail the build if cleaning fails - Warn only

### DIFF
--- a/master/custom/steps.py
+++ b/master/custom/steps.py
@@ -62,7 +62,8 @@ class Test(BaseTest):
 
 class Clean(ShellCommand):
     name = "clean"
-    warnOnFailure = 1
+    flunkOnFailure = False
+    warnOnFailure = True
     description = ["cleaning"]
     descriptionDone = ["clean"]
     command = ["make", "distclean"]


### PR DESCRIPTION
After some investigation, the reason builds like:

https://buildbot.python.org/all/#/builders/16/builds/2013

reported a failure after #69 is not because of a configuration failure, but because the clean step also failed. Notice that clean has `alwaysRuns=True`, and according to the docs:

> alwaysRun
> if True, this build step will always be run, even if a previous buildstep with haltOnFailure=True has failed.


The clean step was marked as `warnOnFailure = True` but not `flunkOnFailure = False` so an error was reported.

This PR fixes this by only warning if the clean step fails.