### PR TITLE
Remove old osx builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -177,7 +177,6 @@ if PRODUCTION:
             UnixInstalledBuild, STABLE),
         ("x86 Gentoo Refleaks", "ware-gentoo-x86", UnixRefleakBuild, STABLE),
         # macOS
-        ("x86-64 El Capitan", "billenstein-elcapitan", UnixBuild, STABLE),
         ("x86-64 High Sierra", "billenstein-sierra", UnixBuild, STABLE),
         # Other Unix
         ("AMD64 FreeBSD 10-STABLE Non-Debug", "koobs-freebsd10",


### PR DESCRIPTION
El Capitan hasn't received updates for a long time and this machine is so old I can't update the OS - it's probably not a practically useful builder any longer.