### PR TITLE
Rename ARMv7 Ubuntu buildbot to ARMv7 Debian

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -167,7 +167,7 @@ if PRODUCTION:
         ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild, STABLE),
         ("AMD64 Debian PGO", "gps-debian-profile-opt", PGOUnixBuild, STABLE),
         ("AMD64 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild, STABLE),
-        ("ARMv7 Ubuntu", "gps-ubuntu-exynos5-armv7l", UnixBuild, STABLE),
+        ("ARMv7 Debian buster", "gps-ubuntu-exynos5-armv7l", UnixBuild, STABLE),
         ("PPC64 Fedora", "edelsohn-fedora-ppc64", UnixBuild, STABLE),
         ("PPC64LE Fedora", "edelsohn-fedora-ppc64le", UnixBuild, STABLE),
         ("s390x SLES", "edelsohn-sles-z", UnixBuild, STABLE),


### PR DESCRIPTION
Because I upgraded the ancient OS.

The `gps-ubuntu-exynos5-armv7l` name is also laughably wrong as that was the original long gone hardware I setup in early 2013 but most people never see that name (it isn't the title on the buildbot pages) so i'm not worried about changing it for now.