### PR TITLE
Fix typo for environment variable  from $(PWD) to ${PWD}

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -26,7 +26,7 @@ class FreezeBuild(TaggedBuildFactory):
     factory_tags = ["freeze"]
 
     def setup(self, **kwargs):
-        self.addStep(Configure(command=["./configure", "--prefix", "$(PWD)/target"]))
+        self.addStep(Configure(command=["./configure", "--prefix", "${PWD}/target"]))
         self.addStep(Compile(command=["make"]))
         self.addStep(
             ShellCommand(
@@ -61,7 +61,7 @@ class UnixBuild(TaggedBuildFactory):
     def setup(self, parallel, test_with_PTY=False, **kwargs):
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "$(PWD)/target"]
+                command=["./configure", "--prefix", "${PWD}/target"]
                 + self.configureFlags
             )
         )
@@ -125,7 +125,7 @@ class UnixInstalledBuild(TaggedBuildFactory):
         installed_python = "./target/bin/python%s" % branch
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "$(PWD)/target"]
+                command=["./configure", "--prefix", "${PWD}/target"]
                 + self.configureFlags
             )
         )


### PR DESCRIPTION
Hope this helps!

p.s. checked that bash also tries to execute PWD with $(PWD) rather than magically provide the expected result.