### PR TITLE
syncronize factory classname schemes for AIXBuild with other platforms

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -26,7 +26,7 @@ class FreezeBuild(TaggedBuildFactory):
     factory_tags = ["freeze"]
 
     def setup(self, **kwargs):
-        self.addStep(Configure(command=["./configure", "--prefix", "${PWD}/target"]))
+        self.addStep(Configure(command=["./configure", "--prefix", "$(PWD)/target"]))
         self.addStep(Compile(command=["make"]))
         self.addStep(
             ShellCommand(
@@ -61,7 +61,7 @@ class UnixBuild(TaggedBuildFactory):
     def setup(self, parallel, test_with_PTY=False, **kwargs):
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "${PWD}/target"]
+                command=["./configure", "--prefix", "$(PWD)/target"]
                 + self.configureFlags
             )
         )
@@ -125,7 +125,7 @@ class UnixInstalledBuild(TaggedBuildFactory):
         installed_python = "./target/bin/python%s" % branch
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "${PWD}/target"]
+                command=["./configure", "--prefix", "$(PWD)/target"]
                 + self.configureFlags
             )
         )

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -168,7 +168,7 @@ class UnixBuildWithoutDocStrings(UnixBuild):
     configureFlags = ["--with-pydebug", "--without-doc-strings"]
 
 
-class AIXBuild(UnixBuild):
+class AIXBuildWithoutComputedGotos(UnixBuild):
     configureFlags = [
         "--with-pydebug",
         "--with-openssl=/opt/aixtools",
@@ -176,11 +176,10 @@ class AIXBuild(UnixBuild):
     ]
 
 
-class AIXBuildWithGcc(UnixBuild):
+class AIXBuild(UnixBuild):
     configureFlags = [
         "--with-pydebug",
         "--with-openssl=/opt/aixtools",
-        "--with-gcc=yes",
     ]
 
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -26,7 +26,7 @@ class FreezeBuild(TaggedBuildFactory):
     factory_tags = ["freeze"]
 
     def setup(self, **kwargs):
-        self.addStep(Configure(command=["./configure", "--prefix", "$(PWD)/target"]))
+        self.addStep(Configure(command=["./configure", "--prefix", "${PWD}/target"]))
         self.addStep(Compile(command=["make"]))
         self.addStep(
             ShellCommand(
@@ -61,7 +61,7 @@ class UnixBuild(TaggedBuildFactory):
     def setup(self, parallel, test_with_PTY=False, **kwargs):
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "$(PWD)/target"]
+                command=["./configure", "--prefix", "${PWD}/target"]
                 + self.configureFlags
             )
         )
@@ -125,7 +125,7 @@ class UnixInstalledBuild(TaggedBuildFactory):
         installed_python = "./target/bin/python%s" % branch
         self.addStep(
             Configure(
-                command=["./configure", "--prefix", "$(PWD)/target"]
+                command=["./configure", "--prefix", "${PWD}/target"]
                 + self.configureFlags
             )
         )

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -32,7 +32,7 @@ from custom.factories import (
     UnixRefleakBuild,
     UnixInstalledBuild,
     AIXBuild,
-    AIXBuildWithGcc,
+    AIXBuildWithoutComputedGotos,
     NonDebugUnixBuild,
     PGOUnixBuild,
     ClangUbsanLinuxBuild,
@@ -211,8 +211,8 @@ if PRODUCTION:
         # macOS
         # Other Unix
         ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
-        ("POWER6 AIX", "aixtools-aix-power6", AIXBuild, UNSTABLE),
-        ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
+        ("POWER6 AIX", "aixtools-aix-power6", AIXBuildWithoutComputedGotos, UNSTABLE),
+        ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
         # Windows
     ]
     dailybuilders = [


### PR DESCRIPTION
The classnames are incorrect - imho. The new names are more inline other platforms (and an incorrect argument that was the basis for one classname is removed).