### PR TITLE
Broken builders now only build on master

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -229,6 +229,16 @@ else:
         'Unix Refleak Test',
     ]
 
+# Match builder name of builders that should only run on the master
+# and "custom" branches.
+ONLY_MASTER_BRANCH = (
+    # 2019-03-08: Test suite only pass on PPC64 AIX 3.x, fail on 2.7 and 3.7
+    "AIX",
+    "Alpine Linux",
+    # Cygwin is not supported on 2.7, 3.6, 3.7
+    "Cygwin",
+)
+
 c['builders'] = []
 c['schedulers'] = []
 
@@ -298,14 +308,18 @@ for git_url, branchname, git_branch in git_branches:
         if "Windows XP" in name and branchname != "2.7":
             # 3.5+ drop support for XP
             continue
-        if "Cygwin" in name and branchname in ("3.6", "3.7", "2.7"):
-            # Cygwin is not supported on these branches.
-            continue
         if "VS9.0" in name and branchname != "2.7":
             continue
         if name.endswith("Freeze") and branchname == "2.7":
             # 2.7 isn't set up for testing freezing
             continue
+        if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
+        and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):
+            # Workers known to be broken on 2.7 and 3.7: let's focus on
+            # supporting these platforms in the master branch. Don't run
+            # custom jobs neither.
+            continue
+
         buildername = name + " " + branchname
         source = Git(
             repourl=git_url,


### PR DESCRIPTION
Only run AIX, Alpine Linux and Clang UBSan on the master branch.