### PR TITLE
Disable notifiations on broken workers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -230,8 +230,8 @@ else:
         'Unix Refleak Test',
     ]
 
-# Match builder name of builders that should only run on the master
-# and "custom" branches.
+# Match builder name (excluding the branch name) of builders that should only
+# run on the master and "custom" branches.
 ONLY_MASTER_BRANCH = (
     # 2019-03-08: Test suite only pass on PPC64 AIX 3.x, fail on 2.7 and 3.7
     "AIX",
@@ -243,9 +243,9 @@ ONLY_MASTER_BRANCH = (
 c['builders'] = []
 c['schedulers'] = []
 
-# Match builder name of builders that should never emit any notification.
-# Basically, notifications are disabled on workers which were never green
-# (tests always failed).
+# Match builder name (including the branch name) of builders that should never
+# emit any notification. Basically, notifications are disabled on workers
+# which were never green (tests always failed).
 NO_NOTIFICATION = (
     "Alpine Linux",
     "Cygwin",
@@ -350,7 +350,7 @@ for git_url, branchname, git_branch in git_branches:
             dailybuildernames.append(buildername)
         else:
             buildernames.append(buildername)
-        if all(pattern not in name for pattern in NO_NOTIFICATION
+        if (all(pattern not in buildername for pattern in NO_NOTIFICATION)
         # disable notifications on custom builders
         and branchname != CUSTOM_BRANCH_NAME):
             mail_status_builders.append(buildername)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -243,6 +243,16 @@ ONLY_MASTER_BRANCH = (
 c['builders'] = []
 c['schedulers'] = []
 
+# Match builder name of builders that should never emit any notification.
+# Basically, notifications are disabled on workers which were never green
+# (tests always failed).
+NO_NOTIFICATION = (
+    "Alpine Linux",
+    "Cygwin",
+    # UBSan always failed on 3.6, 3.7 and 3.x
+    "AMD64 Clang UBSan 3.",
+)
+
 parallel = {
     'cstratak-fedora': '-j10',
     'kloth-win64': '-j4',
@@ -340,8 +350,9 @@ for git_url, branchname, git_branch in git_branches:
             dailybuildernames.append(buildername)
         else:
             buildernames.append(buildername)
+        if all(pattern not in name for pattern in NO_NOTIFICATION
         # disable notifications on custom builders
-        if branchname != CUSTOM_BRANCH_NAME:
+        and branchname != CUSTOM_BRANCH_NAME):
             mail_status_builders.append(buildername)
             # disable GitHub notifications for unstable builders
             if stability == STABLE:


### PR DESCRIPTION
Disable email and IRC notifications on workers which were never green
(tests always failed).