### PR TITLE
Add ClangUnixInstalledBuild. Also add the clang and refleak builds for the AMD64 Fedora Rawhide worker

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -209,6 +209,12 @@ class ClangUbsanLinuxBuild(UnixBuild):
     testFlags = "-j4"
     factory_tags = ["clang", "ubsan", "sanitizer"]
 
+class ClangUnixInstalledBuild(UnixInstalledBuild):
+    configureFlags = [
+        "CC=clang",
+        "LD=clang",
+    ]
+    factory_tags = ["clang", "installed"]
 
 class SharedUnixBuild(UnixBuild):
     configureFlags = ["--with-pydebug", "--enable-shared"]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -209,6 +209,8 @@ if PRODUCTION:
         ("AMD64 Alpine Linux", "ware-alpine", UnixBuild, UNSTABLE),
         ("AMD64 Ubuntu", "einat-ubuntu", UnixBuild, UNSTABLE),
         ("AMD64 Fedora Rawhide", "cstratak-fedora", UnixBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora", UnixRefleakBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora", ClangUnixInstalledBuild, UNSTABLE),
         # Linux other archs
         # macOS
         # Other Unix
@@ -220,6 +222,7 @@ if PRODUCTION:
     dailybuilders = [
         "x86 Gentoo Refleaks",
         "AMD64 Windows8.1 Refleaks",
+        "AMD64 Fedora Rawhide Refleaks",
     ]
 else:
     builders = [


### PR DESCRIPTION
Add a build config for running tests with
an installed python compiled with clang