### PR TITLE
assign Windows arm32 worker

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -369,3 +369,17 @@ class Windows64ICCReleaseBuild(Windows64ReleaseBuild):
     buildersuffix = ".nondebug"
     buildFlags = Windows64ReleaseBuild.buildFlags + windows_icc_build_flags
     factory_tags = ["win64", "icc", "nondebug"]
+
+class WindowsArm32Build(WindowsBuild):
+    buildFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
+    # test_multiprocessing_spawn doesn't complete over simple ssh connection
+    # skip test_multiprocessing_spawn for now
+    testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn"]
+    cleanFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
+    factory_tags = ["arm32"]
+
+class WindowsArm32ReleaseBuild(WindowsArm32Build):
+    buildFlags = WindowsArm32Build.buildFlags + ["-c", "Release"]
+    testFlags = WindowsArm32Build.testFlags + ["+d"]
+    # keep default cleanFlags, both configurations get cleaned
+    factory_tags = ["arm32", "nondebug"]

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -374,7 +374,7 @@ class WindowsArm32Build(WindowsBuild):
     buildFlags = ["-p", "ARM", "--no-tkinter"]
     # test_multiprocessing_spawn doesn't complete over simple ssh connection
     # skip test_multiprocessing_spawn for now
-    testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn", "-x", "test_winconsoleio"]
+    testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn", "-x", "test_winconsoleio", "-x", "test_distutils"]
     cleanFlags = ["-p", "ARM", "--no-tkinter"]
     factory_tags = ["arm32"]
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -376,10 +376,10 @@ class WindowsArm32Build(WindowsBuild):
     # skip test_multiprocessing_spawn for now
     testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn", "-x", "test_winconsoleio", "-x", "test_distutils"]
     cleanFlags = ["-p", "ARM", "--no-tkinter"]
-    factory_tags = ["arm32"]
+    factory_tags = ["win-arm32"]
 
 class WindowsArm32ReleaseBuild(WindowsArm32Build):
     buildFlags = WindowsArm32Build.buildFlags + ["-c", "Release"]
     testFlags = WindowsArm32Build.testFlags + ["+d"]
     # keep default cleanFlags, both configurations get cleaned
-    factory_tags = ["arm32", "nondebug"]
+    factory_tags = ["win-arm32", "nondebug"]

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -374,7 +374,7 @@ class WindowsArm32Build(WindowsBuild):
     buildFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
     # test_multiprocessing_spawn doesn't complete over simple ssh connection
     # skip test_multiprocessing_spawn for now
-    testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn"]
+    testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn", "-x", "test_winconsoleio"]
     cleanFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
     factory_tags = ["arm32"]
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -371,11 +371,11 @@ class Windows64ICCReleaseBuild(Windows64ReleaseBuild):
     factory_tags = ["win64", "icc", "nondebug"]
 
 class WindowsArm32Build(WindowsBuild):
-    buildFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
+    buildFlags = ["-p", "ARM", "--no-tkinter"]
     # test_multiprocessing_spawn doesn't complete over simple ssh connection
     # skip test_multiprocessing_spawn for now
     testFlags = ["-arm32", "-j2", "-x", "test_multiprocessing_spawn", "-x", "test_winconsoleio"]
-    cleanFlags = ["-p", "ARM", "--no-tkinter", "--no-ssl"]
+    cleanFlags = ["-p", "ARM", "--no-tkinter"]
     factory_tags = ["arm32"]
 
 class WindowsArm32ReleaseBuild(WindowsArm32Build):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -221,7 +221,7 @@ if PRODUCTION:
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
         # Windows
         ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
-        ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
+        ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
     ]
     dailybuilders = [
         "x86 Gentoo Refleaks",

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -45,6 +45,8 @@ from custom.factories import (
     Windows64Build,
     Windows64RefleakBuild,
     Windows64ReleaseBuild,
+    WindowsArm32Build,
+    WindowsArm32ReleaseBuild,
 )
 from custom.pr_reporter import GitHubPullRequestReporter
 from custom.steps import Git
@@ -218,6 +220,8 @@ if PRODUCTION:
         ("POWER6 AIX", "aixtools-aix-power6", AIXBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuildWithGcc, UNSTABLE),
         # Windows
+        ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
+        ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
     ]
     dailybuilders = [
         "x86 Gentoo Refleaks",


### PR DESCRIPTION
I expect this worker to fail at first.
For example tools/buildbot/test.bat needs to changed to support this worker: https://github.com/python/cpython/pull/12917
There are also 10 more tests that need skips or fixes that I'm aware of.