### PR TITLE
bpo-36511: Fix Windows arm32 buildbot, pythoninfo, scp, and ssh

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -414,7 +414,7 @@ class WindowsArm32Build(WindowsBuild):
 class WindowsArm32ReleaseBuild(WindowsArm32Build):
     buildersuffix = ".nondebug"
     buildFlags = WindowsArm32Build.buildFlags + ["-c", "Release"]
-    remotePythonInfoFlags = WindowsArm32Build.remotePythonInfoFlags + ["-d"]
+    remotePythonInfoFlags = WindowsArm32Build.remotePythonInfoFlags + ["+d"]
     testFlags = WindowsArm32Build.testFlags + ["+d"]
     # keep default cleanFlags, both configurations get cleaned
     factory_tags = ["win-arm32", "nondebug"]


### PR DESCRIPTION
When running the buildbot for Windows ARM32 test.pythoninfo must be run remotely.
Also seperating deploy step from both pythoninfo and test.bat
This requires a cpython PR to work: https://github.com/python/cpython/pull/13454
I think this should work.  Feedback is appreciated.

@zooba @zware 
