### PR TITLE
AIX passes 3.8 tests

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -240,8 +240,6 @@ else:
 # Match builder name (excluding the branch name) of builders that should only
 # run on the master and "custom" branches.
 ONLY_MASTER_BRANCH = (
-    # 2019-03-08: Test suite only pass on PPC64 AIX 3.x, fail on 2.7 and 3.7
-    "AIX",
     "Alpine Linux",
     # Cygwin is not supported on 2.7, 3.6, 3.7
     "Cygwin",
@@ -335,6 +333,9 @@ for git_url, branchname, git_branch in git_branches:
             continue
         if name.endswith("Freeze") and branchname == "2.7":
             # 2.7 isn't set up for testing freezing
+            continue
+        # 2019-06-18: Test suite - AIX passes on master and 3.8 branch, fail on others
+        if "AIX" in name and branchname not in ("3.8", "3.x", CUSTOM_BRANCH_NAME)):
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
         and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -335,7 +335,7 @@ for git_url, branchname, git_branch in git_branches:
             # 2.7 isn't set up for testing freezing
             continue
         # 2019-06-19: Test suite - AIX passes on master and 3.X branches, fails on 2.7
-        if "AIX" in name and branchname == "2.7":
+        if "AIX" in name and branchname in ("2.7", "3.7"):
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
         and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -334,8 +334,8 @@ for git_url, branchname, git_branch in git_branches:
         if name.endswith("Freeze") and branchname == "2.7":
             # 2.7 isn't set up for testing freezing
             continue
-        # 2019-06-18: Test suite - AIX passes on master and 3.8 branch, fail on others
-        if "AIX" in name and branchname not in ("3.8", "3.x", CUSTOM_BRANCH_NAME):
+        # 2019-06-19: Test suite - AIX passes on master and 3.X branches, fails on 2.7
+        if "AIX" in name and branchname == "2.7"
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
         and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -335,7 +335,7 @@ for git_url, branchname, git_branch in git_branches:
             # 2.7 isn't set up for testing freezing
             continue
         # 2019-06-19: Test suite - AIX passes on master and 3.X branches, fails on 2.7
-        if "AIX" in name and branchname == "2.7"
+        if "AIX" in name and branchname == "2.7":
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
         and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -335,7 +335,7 @@ for git_url, branchname, git_branch in git_branches:
             # 2.7 isn't set up for testing freezing
             continue
         # 2019-06-18: Test suite - AIX passes on master and 3.8 branch, fail on others
-        if "AIX" in name and branchname not in ("3.8", "3.x", CUSTOM_BRANCH_NAME)):
+        if "AIX" in name and branchname not in ("3.8", "3.x", CUSTOM_BRANCH_NAME):
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
         and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):


### PR DESCRIPTION
AIX passes master and 3.8 - as is. The 3.7 backports are finished and awaiting review and merge.