### PR TITLE
[ON HOLD] Change the fedora rawhide worker naming to be more specific

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -210,9 +210,9 @@ if PRODUCTION:
         ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
         ("AMD64 Alpine Linux", "ware-alpine", UnixBuild, UNSTABLE),
         ("AMD64 Ubuntu", "einat-ubuntu", UnixBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide", "cstratak-fedora", UnixBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora", UnixRefleakBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora", ClangUnixInstalledBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", UnixBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-x86_64", UnixRefleakBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-x86_64", ClangUnixInstalledBuild, UNSTABLE),
         # Linux other archs
         # macOS
         # Other Unix
@@ -265,7 +265,7 @@ NO_NOTIFICATION = (
 )
 
 parallel = {
-    'cstratak-fedora': '-j10',
+    'cstratak-fedora-rawhide-x86_64': '-j10',
     'kloth-win64': '-j4',
     # Snakebite
     'koobs-freebsd10': '-j4',


### PR DESCRIPTION
Pending merge till the non-public bits of the infrastructure get renamed as well.