### PR TITLE
Add build configs for link time optimizations

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -244,6 +244,19 @@ class SharedUnixBuild(UnixBuild):
     configureFlags = ["--with-pydebug", "--enable-shared"]
     factory_tags = ["shared"]
 
+class LTONonDebugUnixBuild(NonDebugUnixBuild):
+    configureFlags = [
+        "--with-lto"
+    ]
+    factory_tags = ["lto", "nondebug"]
+
+class LTOPGONonDebugBuild(NonDebugUnixBuild):
+    configureFlags = [
+         "--with-lto"
+         "--enable-optimizations"
+    ]
+    factory_tags = ["lto", "pgo", "nondebug"]
+
 
 class UniversalOSXBuild(UnixBuild):
     configureFlags = [

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -39,6 +39,8 @@ from custom.factories import (
     ClangUbsanLinuxBuild,
     ClangUnixInstalledBuild,
     SharedUnixBuild,
+    LTONonDebugUnixBuild,
+    LTOPGONonDebugBuild,
     WindowsBuild,
     SlowWindowsBuild,
     Windows27VS9Build,


### PR DESCRIPTION
More specifically, add a non debug build which makes
use of the --with-lto flag, and another which also
enables the profile guided optimizations