### PR TITLE
Add Fedora stable, RHEL7 and RHEL8 workers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -187,6 +187,20 @@ if PRODUCTION:
         ("x86 Gentoo Installed with X", "ware-gentoo-x86",
             UnixInstalledBuild, STABLE),
         ("x86 Gentoo Refleaks", "ware-gentoo-x86", UnixRefleakBuild, STABLE),
+        ("AMD64 Fedora Stable", "cstratak-fedora-stable-x86_64", UnixBuild, STABLE),
+        ("AMD64 Fedora Stable Refleaks", "cstratak-fedora-stable-x86_64", UnixRefleakBuild, STABLE),
+        ("AMD64 Fedora Stable Clang", "cstratak-fedora-stable-x86_64", ClangUbsanLinuxBuild, STABLE),
+        ("AMD64 Fedora Stable Clang Installed", "cstratak-fedora-stable-x86_64", ClangUnixInstalledBuild, STABLE),
+        ("AMD64 Fedora Stable LTO", "cstratak-fedora-stable-x86_64", LTONonDebugUnixBuild, STABLE),
+        ("AMD64 Fedora Stable LTO + PGO", "cstratak-fedora-stable-x86_64", LTOPGONonDebugBuild, STABLE),
+        ("AMD64 RHEL7", "cstratak-RHEL7-x86_64", UnixBuild, STABLE),
+        ("AMD64 RHEL7 Refleaks", "cstratak-RHEL7-x86_64", UnixRefleakBuild, STABLE),
+        ("AMD64 RHEL7 LTO", "cstratak-RHEL7-x86_64", LTONonDebugUnixBuild, STABLE),
+        ("AMD64 RHEL7 LTO + PGO", "cstratak-RHEL7-x86_64", LTOPGONonDebugBuild, STABLE),
+        ("AMD64 RHEL8", "cstratak-RHEL8-x86_64", UnixBuild, STABLE),
+        ("AMD64 RHEL8 Refleaks", "cstratak-RHEL8-x86_64", UnixRefleakBuild, STABLE),
+        ("AMD64 RHEL8 LTO", "cstratak-RHEL8-x86_64", LTONonDebugUnixBuild, STABLE),
+        ("AMD64 RHEL8 LTO + PGO", "cstratak-RHEL8-x86_64", LTOPGONonDebugBuild, STABLE),
         # macOS
         ("x86-64 High Sierra", "billenstein-sierra", UnixBuild, STABLE),
         # Other Unix
@@ -214,7 +228,10 @@ if PRODUCTION:
         ("AMD64 Ubuntu", "einat-ubuntu", UnixBuild, UNSTABLE),
         ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", UnixBuild, UNSTABLE),
         ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-x86_64", UnixRefleakBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide Clang", "cstratak-fedora-rawhide-x86_64", ClangUbsanLinuxBuild, UNSTABLE),
         ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-x86_64", ClangUnixInstalledBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide LTO", "cstratak-fedora-rawhide-x86_64", LTONonDebugUnixBuild, UNSTABLE),
+        ("AMD64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-x86_64", LTOPGONonDebugBuild, UNSTABLE),
         # Linux other archs
         # macOS
         # Other Unix
@@ -229,6 +246,9 @@ if PRODUCTION:
         "x86 Gentoo Refleaks",
         "AMD64 Windows8.1 Refleaks",
         "AMD64 Fedora Rawhide Refleaks",
+        "AMD64 Fedora Stable Refleaks",
+        "AMD64 RHEL7 Refleaks",
+        "AMD64 RHEL8 Refleaks",
     ]
 else:
     builders = [
@@ -270,6 +290,9 @@ NO_NOTIFICATION = (
 
 parallel = {
     'cstratak-fedora-rawhide-x86_64': '-j10',
+    'cstratak-fedora-stable-x86_64': '-j10',
+    'cstratak-RHEL7-x86_64': '-j10',
+    'cstratak-RHEL8-x86_64': '-j10',
     'kloth-win64': '-j4',
     # Snakebite
     'koobs-freebsd10': '-j4',


### PR DESCRIPTION
This PR does several things:

Adds a Fedora 30 (the current stable branch of Fedora), a RHEL7 and a RHEL8 x86_64 machines.

For the RHEL7 and RHEL8 machines it adds the unix debug build, the reference leak build once a day and the new configs of LTO and LTO+PGO builds.

For the unstable fedora it adds the normal clang build, as well as the LTO and LTO + PGO builds.

The stable fedora is synced with the unstable one in terms of the build configs.

Also add -j10 for the workers as each one has 8 cores. 