### PR TITLE
Fix a typo in ClangUbsanLinuxBuild suffix

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -216,7 +216,7 @@ class PGOUnixBuild(NonDebugUnixBuild):
 
 
 class ClangUbsanLinuxBuild(UnixBuild):
-    buildersuffix = ".clang-usban"
+    buildersuffix = ".clang-ubsan"
     configureFlags = [
         "CC=clang",
         "LD=clang",


### PR DESCRIPTION
It should be read as "UB san" (Undefined Behavior Sanitizer)