### PR TITLE
Switch from secret local.py file to secret config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ buildbot.sh
 buildbot/
 lib/
 venv/
+worker/

--- a/master/.gitignore
+++ b/master/.gitignore
@@ -6,7 +6,7 @@ custom.*/
 bolen-dmg-*/
 2.7.*/
 3.*.*/
-local.py
+settings.yaml
 workers/
 gitpoller-work/
 master.cfg.sample

--- a/master/custom/settings.py
+++ b/master/custom/settings.py
@@ -1,0 +1,79 @@
+import os
+import secrets
+
+import yaml
+from twisted.python import log
+
+
+DEFAULTS = dict(
+    web_port=9011,
+    worker_port=9021,
+    irc_channel='#buildbot-test',
+    irc_nick='py-bb-test',
+    buildbot_url='http://localhost:9011/',
+    db_url='sqlite:///state.sqlite',
+    do_auth=True,
+    send_mail=False,
+    verbosity=1,
+    git_url='https://github.com/python/cpython',
+)
+
+
+class Settings:
+
+    value = ...
+    path = None
+
+    def __init__(self, value=..., path=None):
+        if value is not ...:
+            self.value = value
+        self.path = path
+
+    @classmethod
+    def from_file(cls, filename):
+        with open(filename) as f:
+            return cls(yaml.full_load(f), path=[])
+
+    def __getitem__(self, key):
+        path_key = real_key = key
+        if isinstance(key, type(self)):
+            path_key = real_key = key.value
+            if real_key is ...:
+                real_key = 'unknown'
+                path_key = key.path
+        new_path = self.path + [path_key]
+        if self.value is not ... and real_key in self.value:
+            value = self.value[real_key]
+            if isinstance(value, (list, dict)):
+                return type(self)(value, path=new_path)
+            return value
+        return type(self)(path=new_path)
+
+    __getattr__ = __getitem__
+
+    def get(self, key, default=...):
+        if self.value is not ...:
+            value = self.value.get(key, default)
+            if value is not ...:
+                return value
+        if default is not ...:
+            return default
+        return type(self)(path=self.path + [key])
+
+    def _convert(self, func, default):
+        if self.value is not ...:
+            return func(self.value)
+        default = DEFAULTS.get('.'.join(map(str, self.path)), default)
+        if not os.getenv('CI'):
+            # Note: We use log.err to make this show up during `checkconfig`
+            log.err(f'WARNING: No setting at {self.path}, returning {default}')
+        return func(default)
+
+    def __int__(self):
+        return self._convert(int, 1)
+
+    def __str__(self):
+        return self._convert(str, secrets.token_urlsafe(8))
+
+    def __bool__(self):
+        return self._convert(bool, False)

--- a/master/custom/settings.py
+++ b/master/custom/settings.py
@@ -27,7 +27,7 @@ class Settings:
     def __init__(self, value=..., path=None):
         if value is not ...:
             self.value = value
-        self.path = path
+        self.path = path or []
 
     @classmethod
     def from_file(cls, filename):

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -1,0 +1,165 @@
+# -*- python -*-  vi:ft=python:
+# kate: indent-mode python; hl python;
+# vim:set ts=8 sw=4 sts=4 et:
+
+from functools import partial
+
+from buildbot.plugins import worker as _worker
+
+
+class CPythonWorker:
+
+    def __init__(self, settings, name,
+                 tags=None, branches=None,
+                 parallel_builders=None, parallel_tests=None):
+        self.name = name
+        self.tags = tags or set()
+        self.branches = branches
+        self.parallel_builders = parallel_builders
+        self.parallel_tests = parallel_tests
+        worker_settings = settings.workers[name]
+        owner = name.split('-')[0]
+        owner_settings = settings.owners[owner]
+        pw = worker_settings.get('password', None) or owner_settings.password
+        owner_email = owner_settings.get('email', None)
+        emails = list(map(str, filter(None, (settings.get('status_email', None), owner_email))))
+        self.bb_worker = _worker.Worker(name, str(pw), notify_on_missing=emails)
+
+
+def get_workers(settings):
+    cpw = partial(CPythonWorker, settings)
+    return [
+        cpw(
+            name="aixtools-aix-power6",
+            tags=['aix', 'unix', 'power6'],
+            branches=['3.8', '3.x'],
+        ),
+        cpw(
+            name="angelico-debian-amd64",
+            tags=['linux', 'unix', 'debian', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="billenstein-sierra",
+            tags=['macOS', 'unix', 'sierra', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="bolen-ubuntu",
+            tags=['linux', 'unix', 'ubuntu', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="bolen-windows10",
+            tags=['windows', 'win10', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="bolen-windows7",
+            tags=['windows', 'win7', 'x86'],
+        ),
+        cpw(
+            name="bolen-windows",
+            tags=['windows', 'winXP', 'x86'],
+            branches=['2.7'],
+        ),
+        cpw(
+            name="bray-win10-cygwin-amd64",
+            tags=['windows', 'win10', 'cygwin', 'unix', 'amd64', 'x86-64'],
+            branches=['3.x'],
+        ),
+        cpw(
+            name="cstratak-fedora-rawhide-x86_64",
+            tags=['linux', 'unix', 'fedora', 'amd64', 'x86-64'],
+            parallel_tests=10,
+        ),
+        cpw(
+            name="cstratak-fedora-stable-x86_64",
+            tags=['linux', 'unix', 'fedora', 'amd64', 'x86-64'],
+            parallel_tests=10,
+        ),
+        cpw(
+            name="cstratak-RHEL7-x86_64",
+            tags=['linux', 'unix', 'rhel', 'amd64', 'x86-64'],
+            parallel_tests=10,
+        ),
+        cpw(
+            name="cstratak-RHEL8-x86_64",
+            tags=['linux', 'unix', 'rhel', 'amd64', 'x86-64'],
+            parallel_tests=10,
+        ),
+        cpw(
+            name="edelsohn-aix-ppc64",
+            tags=['aix', 'unix', 'ppc64'],
+            branches=['3.8', '3.x'],
+        ),
+        cpw(
+            name="edelsohn-debian-z",
+            tags=['linux', 'unix', 'debian', 's390x'],
+        ),
+        cpw(
+            name="edelsohn-fedora-ppc64",
+            tags=['linux', 'unix', 'fedora', 'ppc64'],
+        ),
+        cpw(
+            name="edelsohn-fedora-ppc64le",
+            tags=['linux', 'unix', 'fedora', 'ppc64le'],
+        ),
+        cpw(
+            name="edelsohn-sles-z",
+            tags=['linux', 'unix', 'sles', 's390x'],
+        ),
+        cpw(
+            name="edelsohn-rhel-z",
+            tags=['linux', 'unix', 'rhel', 's390x'],
+        ),
+        cpw(
+            name="einat-ubuntu",
+            tags=['linux', 'unix', 'ubuntu', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="gps-clang-ubsan",
+            tags=['linux', 'unix', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="gps-debian-profile-opt",
+            tags=['linux', 'unix', 'debian', 'amd64', 'x86-64'],
+        ),
+        cpw(
+            name="gps-ubuntu-exynos5-armv7l",
+            tags=['linux', 'unix', 'ubuntu', 'arm', 'armv7', 'arm32'],
+            parallel_tests=8,
+        ),
+        cpw(
+            name="kloth-win64",
+            tags=['windows', 'win7', 'amd64', 'x86-64'],
+            parallel_builders=2,
+            parallel_tests=4,
+        ),
+        cpw(
+            name="koobs-freebsd-9e36",
+            tags=['bsd', 'unix', 'freebsd', 'amd64', 'x86-64'],
+            parallel_tests=4,
+        ),
+        cpw(
+            name="koobs-freebsd-564d",
+            tags=['bsd', 'unix', 'freebsd', 'amd64', 'x86-64'],
+            parallel_tests=4,
+        ),
+        cpw(
+            name="monson-win-arm32",
+            tags=['windows', 'win10', 'arm', 'arm32'],
+            branches=['3.x'],
+        ),
+        cpw(
+            name="ware-alpine",
+            tags=['linux', 'unix', 'alpine', 'docker', 'amd64', 'x86-64'],
+            branches=['3.x'],
+        ),
+        cpw(
+            name="ware-gentoo-x86",
+            tags=['linux', 'unix', 'gentoo', 'x86'],
+            parallel_builders=2,
+        ),
+        cpw(
+            name="ware-win81-release",
+            tags=['windows', 'win8', 'amd64', 'x86-64'],
+            parallel_tests=4,
+        ),
+    ]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -58,7 +58,12 @@ from custom.settings import Settings    # noqa: E402
 from custom.steps import Git    # noqa: E402
 from custom.workers import get_workers  # noqa: E402
 
-settings = Settings.from_file(os.path.join(os.path.dirname(__file__), 'settings.yaml'))
+settings_path = os.path.join(os.path.dirname(__file__), 'settings.yaml')
+try:
+    settings = Settings.from_file(settings_path)
+except FileNotFoundError:
+    log.err(f'WARNING: settings file could not be found at {settings_path}')
+    settings = Settings()
 
 WORKERS = get_workers(settings)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -169,87 +169,86 @@ class SlowSharedUnixBuild(SharedUnixBuild):
 
 # The order below is not really important but I find it makes things neater.
 
-if 'a diff without a big indentation change is desired':
-    builders = [
-        # -- Stable builders --
-        # Linux
-        ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild, STABLE),
-        ("AMD64 Debian PGO", "gps-debian-profile-opt", PGOUnixBuild, STABLE),
-        ("AMD64 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild, STABLE),
-        ("ARMv7 Debian buster", "gps-ubuntu-exynos5-armv7l", UnixBuild, STABLE),
-        ("PPC64 Fedora", "edelsohn-fedora-ppc64", UnixBuild, STABLE),
-        ("PPC64LE Fedora", "edelsohn-fedora-ppc64le", UnixBuild, STABLE),
-        ("s390x SLES", "edelsohn-sles-z", UnixBuild, STABLE),
-        ("s390x Debian", "edelsohn-debian-z", UnixBuild, STABLE),
-        ("s390x RHEL", "edelsohn-rhel-z", UnixBuild, STABLE),
-        ("x86 Gentoo Non-Debug with X", "ware-gentoo-x86",
-            NonDebugUnixBuild, STABLE),
-        ("x86 Gentoo Installed with X", "ware-gentoo-x86",
-            UnixInstalledBuild, STABLE),
-        ("x86 Gentoo Refleaks", "ware-gentoo-x86", UnixRefleakBuild, STABLE),
-        ("AMD64 Fedora Stable", "cstratak-fedora-stable-x86_64", UnixBuild, STABLE),
-        ("AMD64 Fedora Stable Refleaks", "cstratak-fedora-stable-x86_64", UnixRefleakBuild, STABLE),
-        ("AMD64 Fedora Stable Clang", "cstratak-fedora-stable-x86_64", ClangUbsanLinuxBuild, STABLE),
-        ("AMD64 Fedora Stable Clang Installed", "cstratak-fedora-stable-x86_64", ClangUnixInstalledBuild, STABLE),
-        ("AMD64 Fedora Stable LTO", "cstratak-fedora-stable-x86_64", LTONonDebugUnixBuild, STABLE),
-        ("AMD64 Fedora Stable LTO + PGO", "cstratak-fedora-stable-x86_64", LTOPGONonDebugBuild, STABLE),
-        ("AMD64 RHEL7", "cstratak-RHEL7-x86_64", UnixBuild, STABLE),
-        ("AMD64 RHEL7 Refleaks", "cstratak-RHEL7-x86_64", UnixRefleakBuild, STABLE),
-        ("AMD64 RHEL7 LTO", "cstratak-RHEL7-x86_64", LTONonDebugUnixBuild, STABLE),
-        ("AMD64 RHEL7 LTO + PGO", "cstratak-RHEL7-x86_64", LTOPGONonDebugBuild, STABLE),
-        ("AMD64 RHEL8", "cstratak-RHEL8-x86_64", UnixBuild, STABLE),
-        ("AMD64 RHEL8 Refleaks", "cstratak-RHEL8-x86_64", UnixRefleakBuild, STABLE),
-        ("AMD64 RHEL8 LTO", "cstratak-RHEL8-x86_64", LTONonDebugUnixBuild, STABLE),
-        ("AMD64 RHEL8 LTO + PGO", "cstratak-RHEL8-x86_64", LTOPGONonDebugBuild, STABLE),
-        # macOS
-        ("x86-64 High Sierra", "billenstein-sierra", UnixBuild, STABLE),
-        # Other Unix
-        ("AMD64 FreeBSD Non-Debug", "koobs-freebsd-9e36",
-            SlowNonDebugUnixBuild, STABLE),
-        ("AMD64 FreeBSD Shared", "koobs-freebsd-564d",
-            SlowSharedUnixBuild, STABLE),
-        # Windows
-        ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, STABLE),
-        ("AMD64 Windows7 SP1 VS9.0", "kloth-win64",
-            Windows6427VS9Build, STABLE),
-        ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE),
-        ("AMD64 Windows8.1 Non-Debug", "ware-win81-release",
-            Windows64ReleaseBuild, STABLE),
-        ("AMD64 Windows8.1 Refleaks", "ware-win81-release",
-            Windows64RefleakBuild, STABLE),
-        ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, STABLE),
-        ("x86 Windows XP", "bolen-windows", WindowsBuild, STABLE),
-        ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, STABLE),
+builders = [
+    # -- Stable builders --
+    # Linux
+    ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild, STABLE),
+    ("AMD64 Debian PGO", "gps-debian-profile-opt", PGOUnixBuild, STABLE),
+    ("AMD64 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild, STABLE),
+    ("ARMv7 Debian buster", "gps-ubuntu-exynos5-armv7l", UnixBuild, STABLE),
+    ("PPC64 Fedora", "edelsohn-fedora-ppc64", UnixBuild, STABLE),
+    ("PPC64LE Fedora", "edelsohn-fedora-ppc64le", UnixBuild, STABLE),
+    ("s390x SLES", "edelsohn-sles-z", UnixBuild, STABLE),
+    ("s390x Debian", "edelsohn-debian-z", UnixBuild, STABLE),
+    ("s390x RHEL", "edelsohn-rhel-z", UnixBuild, STABLE),
+    ("x86 Gentoo Non-Debug with X", "ware-gentoo-x86",
+        NonDebugUnixBuild, STABLE),
+    ("x86 Gentoo Installed with X", "ware-gentoo-x86",
+        UnixInstalledBuild, STABLE),
+    ("x86 Gentoo Refleaks", "ware-gentoo-x86", UnixRefleakBuild, STABLE),
+    ("AMD64 Fedora Stable", "cstratak-fedora-stable-x86_64", UnixBuild, STABLE),
+    ("AMD64 Fedora Stable Refleaks", "cstratak-fedora-stable-x86_64", UnixRefleakBuild, STABLE),
+    ("AMD64 Fedora Stable Clang", "cstratak-fedora-stable-x86_64", ClangUbsanLinuxBuild, STABLE),
+    ("AMD64 Fedora Stable Clang Installed", "cstratak-fedora-stable-x86_64", ClangUnixInstalledBuild, STABLE),
+    ("AMD64 Fedora Stable LTO", "cstratak-fedora-stable-x86_64", LTONonDebugUnixBuild, STABLE),
+    ("AMD64 Fedora Stable LTO + PGO", "cstratak-fedora-stable-x86_64", LTOPGONonDebugBuild, STABLE),
+    ("AMD64 RHEL7", "cstratak-RHEL7-x86_64", UnixBuild, STABLE),
+    ("AMD64 RHEL7 Refleaks", "cstratak-RHEL7-x86_64", UnixRefleakBuild, STABLE),
+    ("AMD64 RHEL7 LTO", "cstratak-RHEL7-x86_64", LTONonDebugUnixBuild, STABLE),
+    ("AMD64 RHEL7 LTO + PGO", "cstratak-RHEL7-x86_64", LTOPGONonDebugBuild, STABLE),
+    ("AMD64 RHEL8", "cstratak-RHEL8-x86_64", UnixBuild, STABLE),
+    ("AMD64 RHEL8 Refleaks", "cstratak-RHEL8-x86_64", UnixRefleakBuild, STABLE),
+    ("AMD64 RHEL8 LTO", "cstratak-RHEL8-x86_64", LTONonDebugUnixBuild, STABLE),
+    ("AMD64 RHEL8 LTO + PGO", "cstratak-RHEL8-x86_64", LTOPGONonDebugBuild, STABLE),
+    # macOS
+    ("x86-64 High Sierra", "billenstein-sierra", UnixBuild, STABLE),
+    # Other Unix
+    ("AMD64 FreeBSD Non-Debug", "koobs-freebsd-9e36",
+        SlowNonDebugUnixBuild, STABLE),
+    ("AMD64 FreeBSD Shared", "koobs-freebsd-564d",
+        SlowSharedUnixBuild, STABLE),
+    # Windows
+    ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, STABLE),
+    ("AMD64 Windows7 SP1 VS9.0", "kloth-win64",
+        Windows6427VS9Build, STABLE),
+    ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE),
+    ("AMD64 Windows8.1 Non-Debug", "ware-win81-release",
+        Windows64ReleaseBuild, STABLE),
+    ("AMD64 Windows8.1 Refleaks", "ware-win81-release",
+        Windows64RefleakBuild, STABLE),
+    ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, STABLE),
+    ("x86 Windows XP", "bolen-windows", WindowsBuild, STABLE),
+    ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, STABLE),
 
-        # -- Unstable builders --
-        # Linux x86 / AMD64
-        ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
-        ("AMD64 Alpine Linux", "ware-alpine", UnixBuild, UNSTABLE),
-        ("AMD64 Ubuntu", "einat-ubuntu", UnixBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", UnixBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-x86_64", UnixRefleakBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide Clang", "cstratak-fedora-rawhide-x86_64", ClangUbsanLinuxBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-x86_64", ClangUnixInstalledBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide LTO", "cstratak-fedora-rawhide-x86_64", LTONonDebugUnixBuild, UNSTABLE),
-        ("AMD64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-x86_64", LTOPGONonDebugBuild, UNSTABLE),
-        # Linux other archs
-        # macOS
-        # Other Unix
-        ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
-        ("POWER6 AIX", "aixtools-aix-power6", AIXBuildWithoutComputedGotos, UNSTABLE),
-        ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
-        # Windows
-        ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
-        ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
-    ]
-    dailybuilders = [
-        "x86 Gentoo Refleaks",
-        "AMD64 Windows8.1 Refleaks",
-        "AMD64 Fedora Rawhide Refleaks",
-        "AMD64 Fedora Stable Refleaks",
-        "AMD64 RHEL7 Refleaks",
-        "AMD64 RHEL8 Refleaks",
-    ]
+    # -- Unstable builders --
+    # Linux x86 / AMD64
+    ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
+    ("AMD64 Alpine Linux", "ware-alpine", UnixBuild, UNSTABLE),
+    ("AMD64 Ubuntu", "einat-ubuntu", UnixBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", UnixBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-x86_64", UnixRefleakBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide Clang", "cstratak-fedora-rawhide-x86_64", ClangUbsanLinuxBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-x86_64", ClangUnixInstalledBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide LTO", "cstratak-fedora-rawhide-x86_64", LTONonDebugUnixBuild, UNSTABLE),
+    ("AMD64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-x86_64", LTOPGONonDebugBuild, UNSTABLE),
+    # Linux other archs
+    # macOS
+    # Other Unix
+    ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
+    ("POWER6 AIX", "aixtools-aix-power6", AIXBuildWithoutComputedGotos, UNSTABLE),
+    ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
+    # Windows
+    ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
+    ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
+]
+dailybuilders = [
+    "x86 Gentoo Refleaks",
+    "AMD64 Windows8.1 Refleaks",
+    "AMD64 Fedora Rawhide Refleaks",
+    "AMD64 Fedora Stable Refleaks",
+    "AMD64 RHEL7 Refleaks",
+    "AMD64 RHEL8 Refleaks",
+]
 
 # Match builder name (excluding the branch name) of builders that should only
 # run on the master and "custom" branches.

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -20,14 +20,16 @@ from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.plugins import reporters, util
 from buildbot import locks
+from buildbot.www.auth import NoAuth
+from twisted.python import log
 
-sys.path.append(os.path.dirname(__file__))   # noqa: E402
+sys.path.append(os.path.dirname(__file__))
 
 # Make sure locals are up to date on reconfig
 for k in list(sys.modules):
-    if k.split(".")[0] in ["local", "custom"]:
+    if k.split(".")[0] in ["custom"]:
         sys.modules.pop(k)
-from custom.factories import (
+from custom.factories import (  # noqa: E402
     CUSTOM_BRANCH_NAME,
     UnixBuild,
     UnixRefleakBuild,
@@ -51,34 +53,22 @@ from custom.factories import (
     WindowsArm32Build,
     WindowsArm32ReleaseBuild,
 )
-from custom.pr_reporter import GitHubPullRequestReporter
-from custom.steps import Git
+from custom.pr_reporter import GitHubPullRequestReporter    # noqa: E402
+from custom.settings import Settings    # noqa: E402
+from custom.steps import Git    # noqa: E402
+from custom.workers import get_workers  # noqa: E402
 
-# sensitive and/or instance-specific values
-try:
-    from local import (PRODUCTION, VERBOSITY, WORKERS, AUTH,
-                       BUILDBOT_URL, DB_URL, WORKER_PORT, WEB_PORT,
-                       IRC_NICK, IRC_CHANNEL,
-                       STATUS_TOKEN,
-                       GIT_URL, GITHUB_SECRET)
-except ImportError:
-    from buildbot.plugins import worker as _worker
-    from buildbot.www.auth import NoAuth
-    PRODUCTION = False
-    VERBOSITY = 0
-    WORKERS = [_worker.Worker('test-worker', 'badsecret')]
-    AUTH = NoAuth()
-    DB_URL = "sqlite:///state.sqlite"
-    WORKER_PORT = 9021
-    WEB_PORT = 'tcp:9011'
-    BUILDBOT_URL = 'http://localhost:9011/'
-    IRC_NICK = 'py-bb-test'
-    IRC_CHANNEL = '#buildbot-test'
-    STATUS_TOKEN = 'thistokendoesnotwork'
-    GIT_URL = 'https://github.com/python/cpython.git'
-    GITHUB_SECRET = 'thisisntverysecret'
+settings = Settings.from_file(os.path.join(os.path.dirname(__file__), 'settings.yaml'))
 
-if PRODUCTION:
+WORKERS = get_workers(settings)
+
+if bool(settings.do_auth):
+    AUTH = util.GitHubAuth(
+        clientId=str(settings.github_auth_id),
+        clientSecret=str(settings.github_auth_secret),
+        apiVersion=4,
+        getTeamsMembership=True,
+    )
     AUTHZ = util.Authz(
         allowRules=[
             # Admins can do anything.
@@ -114,14 +104,16 @@ if PRODUCTION:
         ]
     )
 else:
-    # Default to open.
+    log.err('WARNING: Web UI is completely open')
+    # Completely open
+    AUTH = NoAuth()
     AUTHZ = util.Authz()
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
 c = BuildmasterConfig = {}
 
-c['db_url'] = DB_URL
+c['db_url'] = str(settings.db_url)
 
 # horizons
 c['changeHorizon'] = 300
@@ -134,16 +126,17 @@ c['configurators'] = [util.JanitorConfigurator(
     dayOfWeek=6
 )]
 
-# workers are set up in local.py
-c['workers'] = WORKERS
+# workers are set up in workers.py
+c['workers'] = [w.bb_worker for w in WORKERS]
 
 # repo url, buildbot category name, git branch name
+git_url = str(settings.git_url)
 git_branches = [
-    (GIT_URL, "3.x", "master"),
-    (GIT_URL, "3.8", "3.8"),
-    (GIT_URL, "3.7", "3.7"),
-    (GIT_URL, "2.7", "2.7"),
-    (GIT_URL, CUSTOM_BRANCH_NAME, "buildbot-custom"),
+    (git_url, "3.x", "master"),
+    (git_url, "3.8", "3.8"),
+    (git_url, "3.7", "3.7"),
+    (git_url, "2.7", "2.7"),
+    (git_url, CUSTOM_BRANCH_NAME, "buildbot-custom"),
     # Add the following line if you want to clean up a particular
     # buildworker branch (here "3.4")
     # XXX Make this work again...
@@ -153,9 +146,12 @@ git_branches = [
 STABLE = "stable"
 UNSTABLE = "unstable"
 
+
 # classes using longer timeout for koobs's very slow buildbots
 class SlowNonDebugUnixBuild(NonDebugUnixBuild):
     test_timeout = 30 * 60
+
+
 class SlowSharedUnixBuild(SharedUnixBuild):
     test_timeout = 30 * 60
 
@@ -173,7 +169,7 @@ class SlowSharedUnixBuild(SharedUnixBuild):
 
 # The order below is not really important but I find it makes things neater.
 
-if PRODUCTION:
+if 'a diff without a big indentation change is desired':
     builders = [
         # -- Stable builders --
         # Linux
@@ -254,14 +250,6 @@ if PRODUCTION:
         "AMD64 RHEL7 Refleaks",
         "AMD64 RHEL8 Refleaks",
     ]
-else:
-    builders = [
-        ('Unix Test', 'test-worker', UnixBuild, STABLE),
-        ('Unix Refleak Test', 'test-worker', UnixRefleakBuild, UNSTABLE),
-    ]
-    dailybuilders = [
-        'Unix Refleak Test',
-    ]
 
 # Match builder name (excluding the branch name) of builders that should only
 # run on the master and "custom" branches.
@@ -298,16 +286,7 @@ NO_NOTIFICATION = (
 )
 
 parallel = {
-    'cstratak-fedora-rawhide-x86_64': '-j10',
-    'cstratak-fedora-stable-x86_64': '-j10',
-    'cstratak-RHEL7-x86_64': '-j10',
-    'cstratak-RHEL8-x86_64': '-j10',
-    'kloth-win64': '-j4',
-    # Snakebite
-    'koobs-freebsd-564d': '-j4',
-    'koobs-freebsd-9e36': '-j4',
-    'gps-ubuntu-exynos5-armv7l': '-j8',
-    'ware-win81-release': '-j4',
+    w.name: f'-j{w.parallel_tests}' for w in WORKERS if w.parallel_tests
 }
 extra_factory_args = {
     'ware-gentoo-x86': {
@@ -317,10 +296,12 @@ extra_factory_args = {
 }
 
 # The following with the worker owners' agreement
-cpulock = locks.WorkerLock("cpu", maxCountForWorker={
-    'kloth-win64': 2,
-    'ware-gentoo-x86': 2,
-})
+cpulock = locks.WorkerLock(
+    "cpu",
+    maxCountForWorker={
+        w.name: w.parallel_builders for w in WORKERS if w.parallel_builders
+    }
+)
 
 
 def is_important_file(filename):
@@ -376,7 +357,7 @@ for git_url, branchname, git_branch in git_branches:
         if "AIX" in name and branchname in ("2.7", "3.7"):
             continue
         if (any(pattern in name for pattern in ONLY_MASTER_BRANCH)
-        and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):
+                and branchname not in ("3.x", CUSTOM_BRANCH_NAME)):
             # Workers known to be broken on 2.7 and 3.7: let's focus on
             # supporting these platforms in the master branch. Don't run
             # custom jobs neither.
@@ -401,8 +382,8 @@ for git_url, branchname, git_branch in git_branches:
         else:
             buildernames.append(buildername)
         if (all(pattern not in buildername for pattern in NO_NOTIFICATION)
-        # disable notifications on custom builders
-        and branchname != CUSTOM_BRANCH_NAME):
+                # disable notifications on custom builders
+                and branchname != CUSTOM_BRANCH_NAME):
             mail_status_builders.append(buildername)
             # disable GitHub notifications for unstable builders
             if stability == STABLE:
@@ -471,7 +452,7 @@ c["schedulers"].append(
 
 c['protocols'] = {
     "pb": {
-        "port": "tcp:{}".format(WORKER_PORT)
+        "port": "tcp:{}".format(settings.worker_port)
     }
 }
 
@@ -479,11 +460,11 @@ c['protocols'] = {
 # http[s]://buildbot.python.org/all/
 
 c['www'] = dict(
-    port=WEB_PORT,
+    port=int(settings.web_port),
     auth=AUTH,
     authz=AUTHZ,
     change_hook_dialects={
-        'github': {'secret': GITHUB_SECRET, 'strict': True},
+        'github': {'secret': str(settings.git_secret), 'strict': True},
     },
     plugins=dict(
         waterfall_view={},
@@ -498,7 +479,7 @@ c['www'] = dict(
 c['services'] = []
 
 
-if PRODUCTION:
+if bool(settings.send_mail):
     c['services'].append(reporters.MailNotifier(
         fromaddr="buildbot@python.org",
         mode="problem",
@@ -511,8 +492,8 @@ if PRODUCTION:
 
 c['services'].append(reporters.IRC(
     host="irc.freenode.org",
-    nick=IRC_NICK,
-    channels=[{"channel": IRC_CHANNEL}],
+    nick=str(settings.irc_nick),
+    channels=[{"channel": str(settings.irc_channel)}],
     allowForce=False,
     notify_events={
         'exceptionToFailure': 1,
@@ -531,15 +512,15 @@ c['services'].append(reporters.IRC(
 ))
 
 c['services'].append(reporters.GitHubStatusPush(
-    STATUS_TOKEN,
+    str(settings.github_status_token),
     builders=github_status_builders,
-    verbose=bool(VERBOSITY),
+    verbose=bool(settings.verbosity),
 ))
 
 c['services'].append(GitHubPullRequestReporter(
-    STATUS_TOKEN,
+    str(settings.github_status_token),
     builders=github_status_builders,
-    verbose=bool(VERBOSITY),))
+    verbose=bool(settings.verbosity),))
 
 # if you set 'manhole', you can telnet into the buildmaster and get an
 # interactive python shell, which may be useful for debugging buildbot
@@ -561,7 +542,7 @@ c['projectURL'] = "https://www.python.org/"
 # with an externally-visible host name which the buildbot cannot figure out
 # without some help.
 
-c['buildbotURL'] = BUILDBOT_URL
+c['buildbotURL'] = str(settings.buildbot_url)
 
 # disable sending of 'buildbotNetUsageData' for now, to improve startup time
 c['buildbotNetUsageData'] = None

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 buildbot[bundle,tls]
+PyYAML
 requests
 treq


### PR DESCRIPTION
The config file can be rather more minimal, and should be easier to generate via Salt.  I'm not trilled with my implementation of the `Settings` class, but it basically does what I want it to do.  I considered using [buildbot's own](https://docs.buildbot.net/2.5.0/manual/secretsmanagement.html) secret management, but none of this is passed to the workers, I'm reluctant to set up a new secret storing service, and I think it would be harder to manage one-file-per-secret rather than one file with all of the secrets.