### PR TITLE
Clean up daily builder scheduling

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -422,7 +422,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
     if dailybuildernames:
         c['schedulers'].append(Nightly(
             name=branchname + '-daily',
-            hour=int(24 / (len(git_branches) - 1) * branch_num),
+            hour=int(branch_num / (len(git_branches) - 1) * 23),
             minute=0,
             change_filter=util.ChangeFilter(branch=git_branch),
             builderNames=dailybuildernames,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -419,13 +419,14 @@ for git_url, branchname, git_branch in git_branches:
         builderNames=buildernames,
         fileIsImportant=is_important_change,
     ))
-    c['schedulers'].append(Nightly(
-        name=branchname + '-daily',
-        hour=0,
-        minute=0,
-        change_filter=util.ChangeFilter(branch=git_branch),
-        builderNames=dailybuildernames,
-    ))
+    if dailybuildernames:
+        c['schedulers'].append(Nightly(
+            name=branchname + '-daily',
+            hour=0,
+            minute=0,
+            change_filter=util.ChangeFilter(branch=git_branch),
+            builderNames=dailybuildernames,
+        ))
 
 
 # Set up aditional schedulers

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -345,7 +345,7 @@ mail_status_builders = []
 
 # Regular builders
 
-for git_url, branchname, git_branch in git_branches:
+for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
     buildernames = []
     dailybuildernames = []
     for name, worker, buildfactory, stability in builders:
@@ -422,7 +422,7 @@ for git_url, branchname, git_branch in git_branches:
     if dailybuildernames:
         c['schedulers'].append(Nightly(
             name=branchname + '-daily',
-            hour=0,
+            hour=int(24 / (len(git_branches) - 1) * branch_num),
             minute=0,
             change_filter=util.ChangeFilter(branch=git_branch),
             builderNames=dailybuildernames,


### PR DESCRIPTION
The main goal here is to split up the long refleak builds throughout the day, so other builds on the refleak hosts hopefully aren't as blocked by refleak builds.