### PR TITLE
Allow github builders to build pull requests on demand

### DIFF
--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -1,0 +1,92 @@
+# Functions to enable buildbot to test pull requests and report back
+import logging
+
+from dateutil.parser import parse as dateparse
+
+from twisted.internet import defer
+from twisted.python import log
+
+from buildbot.www.hooks.github import GitHubEventHandler
+
+TESTING_LABEL = ":hammer: test-with-buildbots"
+
+GITHUB_PROPERTIES_WHITELIST = ["*.labels"]
+
+
+def should_pr_be_tested(change):
+    if TESTING_LABEL in {
+        label["name"]
+        for label in change.properties.asDict().get("github.labels", [set()])[0]
+    }:
+        log.msg(f"Label detected in PR {change.branch} (commit {change.revision})",
+                logLevel=logging.DEBUG)
+        return True
+    log.msg(f"Label not found in PR {change.branch} (commit {change.revision})",
+            logLevel=logging.DEBUG)
+    return False
+
+
+class CustomGitHubEventHandler(GitHubEventHandler):
+    @defer.inlineCallbacks
+    def handle_pull_request(self, payload, event):
+        changes = []
+        number = payload["number"]
+        refname = "refs/pull/{}/{}".format(number, self.pullrequest_ref)
+        basename = payload["pull_request"]["base"]["ref"]
+        commits = payload["pull_request"]["commits"]
+        title = payload["pull_request"]["title"]
+        comments = payload["pull_request"]["body"]
+        repo_full_name = payload["repository"]["full_name"]
+        head_sha = payload["pull_request"]["head"]["sha"]
+
+        log.msg("Processing GitHub PR #{}".format(number), logLevel=logging.DEBUG)
+
+        head_msg = yield self._get_commit_msg(repo_full_name, head_sha)
+        if self._has_skip(head_msg):
+            log.msg(
+                "GitHub PR #{}, Ignoring: "
+                "head commit message contains skip pattern".format(number)
+            )
+            return ([], "git")
+
+        action = payload.get("action")
+        if action not in ("opened", "reopened", "synchronize", "labeled"):
+            log.msg("GitHub PR #{} {}, ignoring".format(number, action))
+            return (changes, "git")
+
+        if action == "labeled" and payload.get("label")["name"] != TESTING_LABEL:
+            log.msg("Invalid label in PR #{}, ignoring".format(number))
+            return (changes, "git")
+        elif TESTING_LABEL not in {
+            label["name"] for label in payload.get("pull_request")["labels"]
+        }:
+            log.msg("Invalid label in PR #{}, ignoring".format(number))
+            return (changes, "git")
+
+        properties = self.extractProperties(payload["pull_request"])
+        properties.update({"event": event})
+        properties.update({"basename": basename})
+        change = {
+            "revision": payload["pull_request"]["head"]["sha"],
+            "when_timestamp": dateparse(payload["pull_request"]["created_at"]),
+            "branch": refname,
+            "revlink": payload["pull_request"]["_links"]["html"]["href"],
+            "repository": payload["repository"]["html_url"],
+            "project": payload["pull_request"]["base"]["repo"]["full_name"],
+            "category": "pull",
+            "author": payload["sender"]["login"],
+            "comments": "GitHub Pull Request #{0} ({1} commit{2})\n{3}\n{4}".format(
+                number, commits, "s" if commits != 1 else "", title, comments
+            ),
+            "properties": properties,
+        }
+
+        if callable(self._codebase):
+            change["codebase"] = self._codebase(payload)
+        elif self._codebase is not None:
+            change["codebase"] = self._codebase
+
+        changes.append(change)
+
+        log.msg("Received {} changes from GitHub PR #{}".format(len(changes), number))
+        return (changes, "git")

--- a/master/custom/steps.py
+++ b/master/custom/steps.py
@@ -2,9 +2,18 @@ import re
 
 from buildbot.steps.shell import ShellCommand, Test as BaseTest
 from buildbot.steps.source.git import Git as _Git
+from buildbot.steps.source.github import GitHub as _GitHub
 
 
 class Git(_Git):
+    # GH-68: If "git clone" fails, mark the whole build as WARNING
+    # (warnOnFailure), not as "FAILURE" (flunkOnFailure)
+    haltOnFailure = True
+    flunkOnFailure = False
+    warnOnFailure = True
+
+
+class GitHub(_GitHub):
     # GH-68: If "git clone" fails, mark the whole build as WARNING
     # (warnOnFailure), not as "FAILURE" (flunkOnFailure)
     haltOnFailure = True

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -15,7 +15,7 @@ import sys
 
 from datetime import timedelta
 
-from buildbot.schedulers.basic import SingleBranchScheduler
+from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.plugins import reporters, util
@@ -54,8 +54,13 @@ from custom.factories import (  # noqa: E402
     WindowsArm32ReleaseBuild,
 )
 from custom.pr_reporter import GitHubPullRequestReporter    # noqa: E402
+from custom.pr_testing import (
+        CustomGitHubEventHandler,
+        should_pr_be_tested,
+        GITHUB_PROPERTIES_WHITELIST,
+        )    # noqa: E402
 from custom.settings import Settings    # noqa: E402
-from custom.steps import Git    # noqa: E402
+from custom.steps import Git, GitHub    # noqa: E402
 from custom.workers import get_workers  # noqa: E402
 
 settings_path = os.path.join(os.path.dirname(__file__), 'settings.yaml')
@@ -430,6 +435,67 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         ))
 
 
+# Set up Pull Request builders
+
+pull_request_builders = []
+
+for name, worker, buildfactory, stability in builders:
+    if stability != STABLE:
+        continue
+
+    if "Windows XP" in name or "VS9.0" in name:
+        continue
+
+    buildername = name + " " + "PR"
+
+    if any(pattern in buildername for pattern in NO_NOTIFICATION):
+        continue
+
+    pull_request_builders.append(buildername)
+
+    source = GitHub(
+            repourl=git_url,
+            timeout=3600,
+            mode='full',
+            method='clean',
+    )
+
+    f = buildfactory(
+            source,
+            parallel=parallel.get(worker),
+            # Use the same downstream branch names as the "custom"
+            # builder (check what the factories are doing with this
+            # parameter for more info).
+            branch="3",
+            **extra_factory_args.get(worker, {})
+    )
+
+    c['builders'].append(
+            util.BuilderConfig(
+                name=buildername,
+                workernames=[worker],
+                builddir='%s.%s%s' % (
+                    "pull_request", worker, getattr(f, 'buildersuffix', '')
+                ),
+                factory=f,
+                tags=[
+                    "PullRequest",
+                    stability,
+                ] + getattr(f, 'tags', []),
+                locks=[cpulock.access('counting')]
+            )
+    )
+
+github_status_builders.extend(pull_request_builders)
+
+c['schedulers'].append(AnyBranchScheduler(
+        name="pull-request-scheduler",
+        change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
+        treeStableTimer=30,  # seconds
+        builderNames=pull_request_builders,
+    ))
+
+
 # Set up aditional schedulers
 
 c["schedulers"].append(
@@ -471,8 +537,16 @@ c['www'] = dict(
     authz=AUTHZ,
     change_hook_dialects={
         'github': {
+            'class': CustomGitHubEventHandler,
             'secret': str(settings.github_change_hook_secret),
             'strict': True,
+            # These are fnmatch-like patterns that are tested against
+            # the flattened version of the payload dictionary of the
+            # received GitHub webhook statuses. For example a.b will get
+            # the contents of PAYLOAD['a']['b']. These contents are attached
+            # to the change object received by the *filter_fn* function of
+            # the change_filter object in the schedulers (if present).
+            'github_property_whitelist': GITHUB_PROPERTIES_WHITELIST,
         },
     },
     plugins=dict(


### PR DESCRIPTION
Allow buildbots to test a pull request and report to it if the PR contains the label ":hammer: test-with-buildbots"