### PR TITLE
Remove the test-with-buildbots label after the build has been scheduled

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -57,7 +57,6 @@ from custom.pr_reporter import GitHubPullRequestReporter    # noqa: E402
 from custom.pr_testing import (
         CustomGitHubEventHandler,
         should_pr_be_tested,
-        GITHUB_PROPERTIES_WHITELIST,
         )    # noqa: E402
 from custom.settings import Settings    # noqa: E402
 from custom.steps import Git, GitHub    # noqa: E402
@@ -540,13 +539,7 @@ c['www'] = dict(
             'class': CustomGitHubEventHandler,
             'secret': str(settings.github_change_hook_secret),
             'strict': True,
-            # These are fnmatch-like patterns that are tested against
-            # the flattened version of the payload dictionary of the
-            # received GitHub webhook statuses. For example a.b will get
-            # the contents of PAYLOAD['a']['b']. These contents are attached
-            # to the change object received by the *filter_fn* function of
-            # the change_filter object in the schedulers (if present).
-            'github_property_whitelist': GITHUB_PROPERTIES_WHITELIST,
+            'token': settings.github_status_token,
         },
     },
     plugins=dict(


### PR DESCRIPTION
It has been requested that, in order to save resources and to avoid
arbitrary code being tested in the buildbots, once the label is
applied it should been removed. In this way every single scheduled build
must correspond to a core developer appliying the label one time.