### PR TITLE
Revert "Don't report missing workers via email"

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -565,7 +565,6 @@ if bool(settings.send_mail):
         sendToInterestedUsers=False,
         extraHeaders={'Reply-To': status_email},
         builders=mail_status_builders,
-        watchedWorkers=None,
     ))
 
 if bool(settings.irc_notice):


### PR DESCRIPTION
Reverts python/buildmaster-config#140

We can restore the original setting now.