### PR TITLE
Allow to use local workers when there is no settings.yaml

### DIFF
--- a/master/custom/settings.py
+++ b/master/custom/settings.py
@@ -21,7 +21,7 @@ DEFAULTS = dict(
     from_email='buildbot@example.org',
     verbosity=1,
     git_url='https://github.com/python/cpython',
-    use_local_worker=True,
+    use_local_worker=False,
 )
 
 

--- a/master/custom/settings.py
+++ b/master/custom/settings.py
@@ -14,13 +14,14 @@ DEFAULTS = dict(
     irc_nick='py-bb-test',
     buildbot_url='http://localhost:9011/',
     db_url='sqlite:///state.sqlite',
-    do_auth=True,
+    do_auth=False,
     send_mail=False,
     status_email='example@example.org',
     email_relay_host='mail.example.org',
     from_email='buildbot@example.org',
     verbosity=1,
     git_url='https://github.com/python/cpython',
+    use_local_worker=True,
 )
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -11,7 +11,8 @@ class CPythonWorker:
 
     def __init__(self, settings, name,
                  tags=None, branches=None,
-                 parallel_builders=None, parallel_tests=None):
+                 parallel_builders=None, parallel_tests=None,
+                 local=False):
         self.name = name
         self.tags = tags or set()
         self.branches = branches
@@ -23,7 +24,10 @@ class CPythonWorker:
         pw = worker_settings.get('password', None) or owner_settings.password
         owner_email = owner_settings.get('email', None)
         emails = list(map(str, filter(None, (settings.get('status_email', None), owner_email))))
-        self.bb_worker = _worker.Worker(name, str(pw), notify_on_missing=emails)
+        if settings.value == ...:
+            self.bb_worker = _worker.LocalWorker(name)
+        else:
+            self.bb_worker = _worker.Worker(name, str(pw), notify_on_missing=emails)
 
 
 def get_workers(settings):

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -24,7 +24,7 @@ class CPythonWorker:
         pw = worker_settings.get('password', None) or owner_settings.password
         owner_email = owner_settings.get('email', None)
         emails = list(map(str, filter(None, (settings.get('status_email', None), owner_email))))
-        if settings.value == ...:
+        if settings.use_local_worker:
             self.bb_worker = _worker.LocalWorker(name)
         else:
             self.bb_worker = _worker.Worker(name, str(pw), notify_on_missing=emails)
@@ -32,6 +32,8 @@ class CPythonWorker:
 
 def get_workers(settings):
     cpw = partial(CPythonWorker, settings)
+    if settings.use_local_worker:
+        return [cpw(name="local-worker")]
     return [
         cpw(
             name="aixtools-aix-power6",

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -11,8 +11,7 @@ class CPythonWorker:
 
     def __init__(self, settings, name,
                  tags=None, branches=None,
-                 parallel_builders=None, parallel_tests=None,
-                 local=False):
+                 parallel_builders=None, parallel_tests=None):
         self.name = name
         self.tags = tags or set()
         self.branches = branches

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,7 +67,7 @@ try:
     settings = Settings.from_file(settings_path)
 except FileNotFoundError:
     log.err(f'WARNING: settings file could not be found at {settings_path}')
-    settings = Settings()
+    settings = Settings({'do_auth': False})
 
 WORKERS = get_workers(settings)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -67,7 +67,7 @@ try:
     settings = Settings.from_file(settings_path)
 except FileNotFoundError:
     log.err(f'WARNING: settings file could not be found at {settings_path}')
-    settings = Settings({'do_auth': False})
+    settings = Settings()
 
 WORKERS = get_workers(settings)
 
@@ -251,6 +251,11 @@ builders = [
     ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
     ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
 ]
+
+# Override with a default simple worker if we are using local workers
+if settings.use_local_worker:
+    builders = [("Test Builder", "local-worker", UnixBuild, STABLE)]
+
 dailybuilders = [
     "x86 Gentoo Refleaks",
     "AMD64 Windows8.1 Refleaks",


### PR DESCRIPTION
When working locally, we need to substitute the workers by `LocalWorker` so we can trigger builds as desired locally and also deactivate auth (so we don't need to log into the local instance using GitHub).