### PR TITLE
Use GitHub actions to deploy on merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Update buildbot master
+      uses: pablogsal/ssh-action@v0.0.7
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: ${{ secrets.PORT }}
+        script: make update-master

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .*
+!.github
 !.gitignore
 backup/
 bin/


### PR DESCRIPTION
This PR uses GitHub actions to execute `update-master` on the server using ssh. The key to connecting to the server is stored in this repo in the `Setting > Secrets` (so obviously nobody can read it but it can be altered by only us). It also makes sure that the master is completely stopped before updating it (as some times it tries to update it when it has not stopped yet and that fails).