### PR TITLE
Disable Refleak 2.7 jobs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -217,6 +217,10 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             # supporting these platforms in the master branch. Don't run
             # custom jobs neither.
             continue
+        if "refleak" in buildfactory.factory_tags and branchname == "2.7":
+            # Python 2.7 reached end of life at 2020-01-01: don't schedule
+            # Refleak 2.7 jobs on it anymore.
+            continue
 
         buildername = name + " " + branchname
         source = Git(


### PR DESCRIPTION
Python 2.7 reached end of life at 2020-01-01: don't schedule Refleak
2.7 jobs on it anymore.