### PR TITLE
Have the refleak builds for aarch64 done once a day

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -189,6 +189,11 @@ DAILYBUILDERS = [
     "s390x Fedora Refleaks",
     "s390x RHEL7 Refleaks",
     "s390x RHEL8 Refleaks",
+    # Linux aarch64
+    "aarch64 Fedora Rawhide Refleaks",
+    "aarch64 Fedora Stable Refleaks",
+    "aarch64 RHEL7 Refleaks",
+    "aarch64 RHEL8 Refleaks",
 ]
 
 # Match builder name (excluding the branch name) of builders that should only


### PR DESCRIPTION
On #169 I added the aarch64 workers and builders, including reference leak builds. However I forgot to add the refleak builds to the daily builder list, so those intensive builds are being run on every commit, hence I need to add them to the daily builders.