### PR TITLE
bpo-39911: Drop Windows 7 support from Python 3.9

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -221,6 +221,9 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             # Python 2.7 reached end of life at 2020-01-01: don't schedule
             # Refleak 2.7 jobs on it anymore.
             continue
+        # bpo-39911: Python 3.9 dropped Windows 7 support
+        if "Windows7" in name and branchname not in ("2.7", "3.7", "3.8"):
+            continue
 
         buildername = name + " " + branchname
         source = Git(


### PR DESCRIPTION
Keep Windows 7 for Python 2.7, 3.7 and 3.8.