### PR TITLE
Remove unsupported Windows 7 from stable builders

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -102,14 +102,9 @@ def get_builders(settings):
         ("AMD64 FreeBSD Non-Debug", "koobs-freebsd-9e36", SlowNonDebugUnixBuild, STABLE),
         ("AMD64 FreeBSD Shared", "koobs-freebsd-564d", SlowSharedUnixBuild, STABLE),
         # Windows
-        ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, STABLE),
-        ("AMD64 Windows7 SP1 VS9.0", "kloth-win64", Windows6427VS9Build, STABLE),
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE),
         ("AMD64 Windows8.1 Non-Debug", "ware-win81-release", Windows64ReleaseBuild, STABLE),
         ("AMD64 Windows8.1 Refleaks", "ware-win81-release", Windows64RefleakBuild, STABLE),
-        ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, STABLE),
-        ("x86 Windows XP", "bolen-windows", WindowsBuild, STABLE),
-        ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, STABLE),
         # -- Unstable builders --
         # Linux x86 / AMD64
         ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
@@ -169,6 +164,12 @@ def get_builders(settings):
         # Windows
         ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
         ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
+        # Unsupported Windows
+        ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, UNSTABLE),
+        ("AMD64 Windows7 SP1 VS9.0", "kloth-win64", Windows6427VS9Build, UNSTABLE),
+        ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, UNSTABLE),
+        ("x86 Windows XP", "bolen-windows", WindowsBuild, UNSTABLE),
+        ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, UNSTABLE),
     ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -105,6 +105,8 @@ def get_builders(settings):
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE),
         ("AMD64 Windows8.1 Non-Debug", "ware-win81-release", Windows64ReleaseBuild, STABLE),
         ("AMD64 Windows8.1 Refleaks", "ware-win81-release", Windows64RefleakBuild, STABLE),
+        ("x86 Windows XP", "bolen-windows", WindowsBuild, STABLE),
+        ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, STABLE),
         # -- Unstable builders --
         # Linux x86 / AMD64
         ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
@@ -168,8 +170,6 @@ def get_builders(settings):
         ("AMD64 Windows7 SP1", "kloth-win64", Windows64Build, UNSTABLE),
         ("AMD64 Windows7 SP1 VS9.0", "kloth-win64", Windows6427VS9Build, UNSTABLE),
         ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, UNSTABLE),
-        ("x86 Windows XP", "bolen-windows", WindowsBuild, UNSTABLE),
-        ("x86 Windows XP VS9.0", "bolen-windows", Windows27VS9Build, UNSTABLE),
     ]
 
 


### PR DESCRIPTION
See https://github.com/python/buildmaster-config/issues/168.