### PR TITLE
Add a FIPS enabled RHEL8 buildbot

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -125,6 +125,7 @@ def get_builders(settings):
         ("AMD64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-x86_64", LTOPGONonDebugBuild, UNSTABLE),
         ("AMD64 Arch Linux TraceRefs", "pablogsal-arch-x86_64", UnixTraceRefsBuild, STABLE),
         ("AMD64 Arch Linux VintageParser", "pablogsal-arch-x86_64", UnixVintageParserBuild, UNSTABLE),
+        ("AMD64 RHEL8 FIPS", "cstratak-RHEL8-fips-x86_64", UnixBuild, UNSTABLE),
         # Linux PPC64le
         ("PPC64LE Fedora Rawhide", "cstratak-fedora-rawhide-ppc64le", UnixBuild, UNSTABLE),
         ("PPC64LE Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-ppc64le", UnixRefleakBuild, UNSTABLE),
@@ -209,4 +210,6 @@ ONLY_MASTER_BRANCH = (
     "ARM32 Windows",
     # Only the master branch has two parsers
     "VintageParser",
+    # Test under FIPS mode only on the master branch
+    "AMD64 RHEL8 FIPS",
 )

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -132,6 +132,11 @@ def get_workers(settings):
             parallel_tests=10,
         ),
         cpw(
+            name="cstratak-RHEL8-fips-x86_64",
+            tags=['linux', 'unix', 'rhel', 'amd64', 'x86-64'],
+            parallel_tests=6,
+        ),
+        cpw(
             name="edelsohn-aix-ppc64",
             tags=['aix', 'unix', 'ppc64'],
             branches=['3.8', '3.x'],


### PR DESCRIPTION
Addition of RHEL 8 buildbot with [FIPS mode](https://en.wikipedia.org/wiki/FIPS_140-2) enabled.

This config is experimental, and Python will possibly not compile at all initially with it. Adding it to the unstable list, and feel free to turn off the notifications from it.