### PR TITLE
Do not report back to GitHub with the PR buildeers

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -312,8 +312,6 @@ for name, worker, buildfactory, stability in BUILDERS:
         )
     )
 
-github_status_builders.extend(pull_request_builders)
-
 c["schedulers"].append(
     AnyBranchScheduler(
         name="pull-request-scheduler",
@@ -411,7 +409,7 @@ if bool(settings.irc_notice):
 c["services"].append(
     reporters.GitHubStatusPush(
         str(settings.github_status_token),
-        builders=github_status_builders,
+        builders=github_status_builders + pull_request_builders,
         verbose=bool(settings.verbosity),
     )
 )


### PR DESCRIPTION
It seems that the PR builders can get confused if a pull requests
contains commits of another pull request when ussing the
`test-with-buildbots` label. For instance, this PR:

https://github.com/python/cpython/pull/20006

included messages that report to a commit that lives in another PR where
the label was added. To avoid this, exclude the PR builders from the
GitHub notification system.