### PR TITLE
Add ASAN_OPTIONS='detect_leaks=0' to the ASAN builder to avoid false positives

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -223,6 +223,7 @@ class UnixAsanBuild(UnixBuild):
     buildersuffix = ".asan"
     configureFlags = ["--with-pydebug", "--without-pymalloc", "--with-address-sanitizer"]
     factory_tags = ["asan", "sanitizer"]
+    test_environ = {'ASAN_OPTIONS': 'detect_leaks=0'}
 
 
 class UnixBuildWithoutDocStrings(UnixBuild):


### PR DESCRIPTION
…