### PR TITLE
Configure the PGO bot to use --with-readline=edit on 3.10+

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -267,6 +267,14 @@ class PGOUnixBuild(NonDebugUnixBuild):
     buildersuffix = ".pgo"
     configureFlags = ["--enable-optimizations"]
     factory_tags = ["pgo"]
+    
+    def setup(self, parallel, branch, *args, **kwargs):
+        # Only Python >3.10 has --with-readline=edit
+        if branch not in {'3.7', '3.8', '3.9'}:
+            # Use libedit instead of libreadline on this buildbot for
+            # some libedit Linux compilation coverage.
+            self.configureFlags = self.configureFlags + ["--with-readline=edit"]
+        return super().setup(parallel, branch, *args, **kwargs)
 
 class ClangUnixBuild(UnixBuild):
     buildersuffix = ".clang"


### PR DESCRIPTION
This is just to add coverage of that configure option to at least one Linux buildbot. I control that one.

The prerequisite issue https://bugs.python.org/issue43172 has been fixed.