### PR TITLE
Aix ppc64 xlc builder

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -7,6 +7,7 @@ from custom.factories import (
     UnixRefleakBuild,
     UnixInstalledBuild,
     AIXBuild,
+    AIXBuildWithXLC,
     AIXBuildWithoutComputedGotos,
     NonDebugUnixBuild,
     PGOUnixBuild,
@@ -181,6 +182,7 @@ def get_builders(settings):
         ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
         ("POWER6 AIX", "aixtools-aix-power6", AIXBuildWithoutComputedGotos, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
+        ("PPC64 AIX XLC", "edelsohn-aix-ppc64", AIXBuildWithXLC, UNSTABLE),
         # Windows
         ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
         ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -255,6 +255,17 @@ class AIXBuild(UnixBuild):
         "--with-pydebug",
         "--with-openssl=/opt/aixtools",
     ]
+    
+    
+class AIXBuildWithXLC(UnixBuild):
+    buildersuffix = ".xlc"
+    configureFlags = [
+        "--with-pydebug",
+        "--with-openssl=/opt/aixtools",
+        "CC=xlc_r",
+        "LD=xlc_r",
+    ]
+    factory_tags = ["xlc"]
 
 
 class NonDebugUnixBuild(UnixBuild):


### PR DESCRIPTION
Python on AIX is available in a version built with IBM XLC and a version built with GCC, so builders for each configuration would be beneficial.

This patch updates the Python Buildbot configuration to add a factory to use the IBM XLC compiler and a builder on the edelsohn-aix-ppc64 worker to use the new factory.