### PR TITLE
Use Git "fresh" method

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -227,8 +227,10 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             repourl=git_url,
             branch=git_branch,
             timeout=3600,
+            # "git clean -fdx": remove all files which are not tracked by Git,
+            # ignoring the .gitignore rules (ex: remove also ".o" files).
             mode="full",
-            method="clean",
+            method="fresh",
         )
         f = buildfactory(
             source,


### PR DESCRIPTION
Git "clean" method keeps most files created by a previous build. Use
Git "fresh" method instead to ignores .gitignore rules and so remove
all generated files (like ".o" files): run a fresh build rather than
an incremental build.