### PR TITLE
Block setuptools 58 and newer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ clean:
 
 $(VENV_CHECK): requirements.txt
 	$(SYSTEM_PYTHON) -m venv --clear venv
-	$(PIP) install -U pip setuptools wheel
+	$(PIP) install -U pip 'setuptools<58.0' wheel
 	$(PIP) install -r requirements.txt
 
 regen-requirements:
 	$(SYSTEM_PYTHON) -m venv --clear venv
-	$(PIP) install -U pip setuptools wheel
+	$(PIP) install -U pip 'setuptools<58.0' wheel
 	$(PIP) install -U -r requirements.in
 	$(PIP) freeze > requirements.txt
 


### PR DESCRIPTION
buildbot is not compatible with setuptools 58 which removes the
use_2to3 option:

* https://github.com/buildbot/buildbot/issues/6229
* https://bugs.launchpad.net/sqlalchemy-migrate/+bug/1943127