### PR TITLE
Fix #276: Remove monson-win-arm32 builder

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -187,9 +187,6 @@ def get_builders(settings):
         ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
         ("PPC64 AIX XLC", "edelsohn-aix-ppc64", AIXBuildWithXLC, UNSTABLE),
-        # Windows
-        ("ARM32 Windows10 1903", "monson-win-arm32", WindowsArm32Build, UNSTABLE),
-        ("ARM32 Windows10 1903 Non-Debug", "monson-win-arm32", WindowsArm32ReleaseBuild, UNSTABLE),
     ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -28,8 +28,6 @@ from custom.factories import (
     Windows64Build,
     Windows64RefleakBuild,
     Windows64ReleaseBuild,
-    WindowsArm32Build,
-    WindowsArm32ReleaseBuild,
 )
 
 STABLE = "stable"
@@ -219,6 +217,4 @@ ONLY_MASTER_BRANCH = (
     "Alpine Linux",
     # Cygwin is not supported on 2.7, 3.6, 3.7
     "Cygwin",
-    # ARM32 Windows support is 3.8+ only
-    "ARM32 Windows",
 )

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -525,36 +525,3 @@ class Windows64ReleaseBuild(Windows64Build):
     testFlags = Windows64Build.testFlags + ["+d"]
     # keep default cleanFlags, both configurations get cleaned
     factory_tags = ["win64", "nondebug"]
-
-
-windows_icc_build_flags = ["--no-tkinter", "/p:PlatformToolset=Intel C++ Compiler 16.0"]
-
-
-class WindowsArm32Build(WindowsBuild):
-    buildFlags = ["-p", "ARM", "--no-tkinter"]
-    # test_multiprocessing_spawn doesn't complete over simple ssh connection
-    # skip test_multiprocessing_spawn for now
-    remoteTest = True
-    remoteDeployFlags = ["-arm32"]
-    remotePythonInfoFlags = ["-arm32"]
-    testFlags = [
-        "-p",
-        "ARM",
-        "-x",
-        "test_multiprocessing_spawn",
-        "-x",
-        "test_winconsoleio",
-        "-x",
-        "test_distutils",
-    ]
-    cleanFlags = ["-p", "ARM", "--no-tkinter"]
-    factory_tags = ["win-arm32"]
-
-
-class WindowsArm32ReleaseBuild(WindowsArm32Build):
-    buildersuffix = ".nondebug"
-    buildFlags = WindowsArm32Build.buildFlags + ["-c", "Release"]
-    remotePythonInfoFlags = WindowsArm32Build.remotePythonInfoFlags + ["+d"]
-    testFlags = WindowsArm32Build.testFlags + ["+d"]
-    # keep default cleanFlags, both configurations get cleaned
-    factory_tags = ["win-arm32", "nondebug"]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -220,11 +220,6 @@ def get_workers(settings):
             parallel_tests=4,
         ),
         cpw(
-            name="monson-win-arm32",
-            tags=['windows', 'win10', 'arm', 'arm32'],
-            branches=['3.x'],
-        ),
-        cpw(
             name="pablogsal-arch-x86_64",
             tags=['linux', 'unix', 'arch', 'amd64', 'x86-64'],
         ),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -149,8 +149,6 @@ NO_NOTIFICATION = (
     "Cygwin",
     # UBSan always failed on 3.6, 3.7 and 3.x
     "AMD64 Clang UBSan 3.",
-    # Guilty until proven innocent
-    "ARM32 Windows",
 )
 
 parallel = {w.name: f"-j{w.parallel_tests}" for w in WORKERS if w.parallel_tests}


### PR DESCRIPTION
Steve Dower wrote: "It has gone away, and doesn't seem like it'll
ever come back. (I'm not thrilled about it, since I vouched for it
being added, but it's out of my control.)".