### PR TITLE
Restrict macOS M1 builders to 3.9+

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -400,9 +400,9 @@ class RHEL8NoBuiltinHashesUnixBuild(RHEL8Build):
 class MacOSWithBrewBuild(RHEL8Build):
     buildersuffix = ".macos-with-brew"
     configureFlags = UnixBuild.configureFlags + [
-        "--with-openssl=$(brew --prefix openssl)",
-        "CFLAGS=-I$(brew --prefix)/include",
-	"LDFLAGS=-L$(brew --prefix)/lib",
+        "--with-openssl=/opt/homebrew/opt/openssl@3",
+        "CFLAGS=-I/opt/homebrew/include",
+	"LDFLAGS=-L/opt/homebrew/lib",
     ]
 
 ##############################################################################

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -227,6 +227,10 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         if "VintageParser" in name and branchname != "3.9":
             continue
 
+        # MacOS M1+ chips only support 3.9+
+        if "ARM64 macOS" in name and branchname not in ("3.7", "3.8"):
+            continue
+
         buildername = name + " " + branchname
         source = Git(repourl=git_url, branch=git_branch, **GIT_KWDS)
         f = buildfactory(


### PR DESCRIPTION
- Add new MacOS with brew builder
- Restrict macOS M1 builders to 3.9+
