### PR TITLE
add win/arm64 factory classes and build worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -189,8 +189,8 @@ def get_builders(settings):
         ("PPC64 AIX XLC", "edelsohn-aix-ppc64", AIXBuildWithXLC, UNSTABLE),
 
         # Windows/arm64
-        ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE),
-        ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild, STABLE),
+        ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, UNSTABLE),
+        ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE),
     ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -27,6 +27,8 @@ from custom.factories import (
     Windows64RefleakBuild,
     Windows64ReleaseBuild,
     MacOSArmWithBrewBuild,
+    WindowsARM64Build,
+    WindowsARM64ReleaseBuild,
 )
 
 STABLE = "stable"
@@ -185,6 +187,10 @@ def get_builders(settings):
         ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
         ("PPC64 AIX XLC", "edelsohn-aix-ppc64", AIXBuildWithXLC, UNSTABLE),
+
+        # Windows/arm64
+        ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE),
+        ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild, STABLE),
     ]
 
 
@@ -217,4 +223,5 @@ ONLY_MASTER_BRANCH = (
     "Alpine Linux",
     # Cygwin is not supported on 2.7, 3.6, 3.7
     "Cygwin",
+    "ARM64 Windows"
 )

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -509,3 +509,17 @@ class Windows64ReleaseBuild(Windows64Build):
     testFlags = Windows64Build.testFlags + ["+d"]
     # keep default cleanFlags, both configurations get cleaned
     factory_tags = ["win64", "nondebug"]
+
+
+class WindowsARM64Build(WindowsBuild):
+    buildFlags = ["-p", "ARM64"]
+    testFlags = ["-p", "ARM64", "-j2"]
+    cleanFlags = ["-p", "ARM64"]
+    factory_tags = ["win-arm64"]
+
+class WindowsARM64ReleaseBuild(WindowsARM64Build):
+    buildersuffix = ".nondebug"
+    buildFlags = WindowsARM64Build.buildFlags + ["-c", "Release"]
+    testFlags = WindowsARM64Build.testFlags + ["+d"]
+    # keep default cleanFlags, both configurations get cleaned
+    factory_tags = ["win-arm64", "nondebug"]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -249,4 +249,10 @@ def get_workers(settings):
             tags=['windows', 'win8', 'amd64', 'x86-64'],
             parallel_tests=4,
         ),
+        cpw(
+            name="linaro-win-arm64",
+            tags=['windows', 'arm64'],
+            parallel_tests=4,
+        ),
+
     ]


### PR DESCRIPTION
The change adds factory classes for windows/arm64 platforms and adds build worker `linaro-win-arm64` 