### PR TITLE
Add Oracle Solaris SPARC build worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -188,6 +188,7 @@ def get_builders(settings):
         ("AMD64 Cygwin64 on Windows 10", "bray-win10-cygwin-amd64", UnixBuild, UNSTABLE),
         ("PPC64 AIX", "edelsohn-aix-ppc64", AIXBuild, UNSTABLE),
         ("PPC64 AIX XLC", "edelsohn-aix-ppc64", AIXBuildWithXLC, UNSTABLE),
+        ("SPARCv9 Oracle Solaris 11.4", "kulikjak-solaris-sparcv9", UnixBuild, UNSTABLE),
 
         # Windows/arm64
         ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE),

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -225,6 +225,12 @@ def get_workers(settings):
             parallel_tests=4,
         ),
         cpw(
+            name="kulikjak-solaris-sparcv9",
+            tags=['solaris', 'unix', 'sparc', 'sparcv9'],
+            branches=['3.9', '3.10', '3.x'],
+            parallel_tests=4,
+        ),
+        cpw(
             name="pablogsal-arch-x86_64",
             tags=['linux', 'unix', 'arch', 'amd64', 'x86-64'],
             branches=['3.9', '3.10', '3.x'],


### PR DESCRIPTION
I cloned this repo and tested everything internally. There are a few failing tests, but some of those have open PRs with fixes already and the rest can be fixed once the worker is running (right?).
