### PR TITLE
Revert "Mark AMD64 Debian root builder as unstable"

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -59,7 +59,7 @@ def get_builders(settings):
     return [
         # -- Stable builders --
         # Linux
-        ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild, UNSTABLE),
+        ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild, STABLE),
         ("AMD64 Debian PGO", "gps-debian-profile-opt", PGOUnixBuild, STABLE),
         ("AMD64 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild, STABLE),
         ("PPC64 Fedora", "edelsohn-fedora-ppc64", FedoraStableBuild, STABLE),


### PR DESCRIPTION
Reverts python/buildmaster-config#296 now that the builder is stable again:

https://buildbot.python.org/all/#/builders/345