### PR TITLE
Enable assertions in NonDebugUnixBuild.

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -19,6 +19,9 @@ from custom.factories import (
     ClangUbsanLinuxBuild,
     ClangUnixInstalledBuild,
     SharedUnixBuild,
+    SlowNonDebugUnixBuild,
+    SlowSharedUnixBuild,
+    SlowUnixInstalledBuild,
     LTONonDebugUnixBuild,
     LTOPGONonDebugBuild,
     RHEL8NoBuiltinHashesUnixBuild,
@@ -36,22 +39,6 @@ from custom.factories import (
 
 STABLE = "stable"
 UNSTABLE = "unstable"
-# faulthandler uses a timeout 5 minutes smaller: it should be enough for the
-# slowest test.
-SLOW_TIMEOUT = 40 * 60
-
-
-# classes using longer timeout for koobs's very slow buildbots
-class SlowNonDebugUnixBuild(NonDebugUnixBuild):
-    test_timeout = SLOW_TIMEOUT
-
-
-class SlowSharedUnixBuild(SharedUnixBuild):
-    test_timeout = SLOW_TIMEOUT
-
-
-class SlowUnixInstalledBuild(UnixInstalledBuild):
-    test_timeout = SLOW_TIMEOUT
 
 
 def get_builders(settings):

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -272,7 +272,7 @@ class NonDebugUnixBuild(UnixBuild):
     buildersuffix = ".nondebug"
     # Enable assertions regardless. Some children will override this,
     # that is fine.
-    configureFlags = ["-UNDEBUG"]
+    configureFlags = ["CFLAGS=-UNDEBUG"]
     factory_tags = ["nondebug"]
 
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -270,7 +270,9 @@ class AIXBuildWithXLC(UnixBuild):
 
 class NonDebugUnixBuild(UnixBuild):
     buildersuffix = ".nondebug"
-    configureFlags = []
+    # Enable assertions regardless. Some children will override this,
+    # that is fine.
+    configureFlags = ["-UNDEBUG"]
     factory_tags = ["nondebug"]
 
 
@@ -327,6 +329,24 @@ class ClangUnixInstalledBuild(UnixInstalledBuild):
 class SharedUnixBuild(UnixBuild):
     configureFlags = ["--with-pydebug", "--enable-shared"]
     factory_tags = ["shared"]
+
+
+# faulthandler uses a timeout 5 minutes smaller: it should be enough for the
+# slowest test.
+SLOW_TIMEOUT = 40 * 60
+
+
+# These use a longer timeout for very slow buildbots.
+class SlowNonDebugUnixBuild(NonDebugUnixBuild):
+    test_timeout = SLOW_TIMEOUT
+
+
+class SlowSharedUnixBuild(SharedUnixBuild):
+    test_timeout = SLOW_TIMEOUT
+
+
+class SlowUnixInstalledBuild(UnixInstalledBuild):
+    test_timeout = SLOW_TIMEOUT
 
 
 class LTONonDebugUnixBuild(NonDebugUnixBuild):


### PR DESCRIPTION
Also moves all build classes into factories.py where the rest of those live.