### PR TITLE
Lower gps-raspbian test parallelism.

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -211,7 +211,7 @@ def get_workers(settings):
             name="gps-raspbian",
             tags=['linux', 'unix', 'raspbian', 'debian', 'armv6', 'armv7l',
                   'aarch32', 'arm'],
-            parallel_tests=6,
+            parallel_tests=3,
         ),
         cpw(
             name="kloth-win11",


### PR DESCRIPTION
Our long tail slow tests all involve multiple processes running at
once.  Letting too many things run at once exacerbates their troubles
and can lead to timeouts.