### PR TITLE
Double UnixAsanBuild timeout (20 to 40 min)

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -239,6 +239,8 @@ class UnixAsanBuild(UnixBuild):
     # These tests are currently raising false positives or are interfering with the ASAN mechanism,
     # so we need to skip them unfortunately.
     testFlags = ("-j1 -x test_ctypes test_capi test_crypt test_decimal test_faulthandler test_interpreters")
+    # Sometimes test_multiprocessing_fork times out after 15 minutes
+    test_timeout = TEST_TIMEOUT * 2
 
 
 class UnixAsanDebugBuild(UnixAsanBuild):


### PR DESCRIPTION
Recent AMD64 Arch Linux Asan 3.x failure:

    (...)
    test_fork (test.test_multiprocessing_fork.WithProcessesTestQueue) ... ok
    Timeout (0:15:00)!
    (...)