### PR TITLE
Fix buildbot reporters warnings

### DIFF
--- a/master/custom/email_formatter.py
+++ b/master/custom/email_formatter.py
@@ -57,7 +57,7 @@ class CustomMessageFormatter(reporters.MessageFormatter):
 MESSAGE_FORMATTER = CustomMessageFormatter(
     template=MAIL_TEMPLATE,
     template_type="plain",
-    wantLogs=True,
-    wantProperties=True,
-    wantSteps=True,
+    want_logs=True,
+    want_properties=True,
+    want_steps=True,
 )

--- a/master/custom/pr_reporter.py
+++ b/master/custom/pr_reporter.py
@@ -82,7 +82,7 @@ class GitHubPullRequestReporter(reporters.GitHubStatusPush):
         if state != "failure":
             return
 
-        yield getDetailsForBuild(self.master, build, wantLogs=True, wantSteps=True)
+        yield getDetailsForBuild(self.master, build, want_logs=True, want_steps=True)
 
         logs, tracebacks = get_logs_and_tracebacks_from_build(build)
 


### PR DESCRIPTION
Fix 3 warnings from buildbot/reporters/message.py,
"DeprecatedApiWarning: [3.4.0 and later] CustomMessageFormatter":

* wantLogs has been deprecated, use want_logs and want_logs_content
* wantProperties has been deprecated, use want_properties
* wantSteps has been deprecated, use want_steps