### PR TITLE
ASAN and UB workers no longer exclude tests

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -236,9 +236,6 @@ class UnixAsanBuild(UnixBuild):
     # SIGSEGV is ignored on purpose.
     compile_environ = {'ASAN_OPTIONS': 'detect_leaks=0:allocator_may_return_null=1:handle_segv=0'}
     test_environ = {'ASAN_OPTIONS': 'detect_leaks=0:allocator_may_return_null=1:handle_segv=0'}
-    # These tests are currently raising false positives or are interfering with the ASAN mechanism,
-    # so we need to skip them unfortunately.
-    testFlags = ("-j1 -x test_ctypes test_capi test_crypt test_decimal test_faulthandler test_interpreters")
     # Sometimes test_multiprocessing_fork times out after 15 minutes
     test_timeout = TEST_TIMEOUT * 2
 
@@ -310,10 +307,6 @@ class ClangUbsanLinuxBuild(UnixBuild):
         "--with-undefined-behavior-sanitizer",
     ]
     factory_tags = ["clang", "ubsan", "sanitizer"]
-
-    # These tests are currently raising false positives or are interfering with the USAN mechanism,
-    # so we need to skip them unfortunately.
-    testFlags = "-j1 -x test_faulthandler test_hashlib test_concurrent_futures test_ctypes"
 
 
 class ClangUnixInstalledBuild(UnixInstalledBuild):


### PR DESCRIPTION
Python now skips tests on ASAN, MSAN and UBSAN builds:
https://bugs.python.org/issue46633