### PR TITLE
Update Solaris worker configuration

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -242,7 +242,7 @@ def get_workers(settings):
             name="kulikjak-solaris-sparcv9",
             tags=['solaris', 'unix', 'sparc', 'sparcv9'],
             branches=['3.9', '3.10', '3.x'],
-            parallel_tests=4,
+            parallel_tests=16,
         ),
         cpw(
             name="pablogsal-arch-x86_64",

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -218,8 +218,12 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         if "VintageParser" in name and branchname != "3.9":
             continue
 
-        # Only 3.9+ is known to pass the USAN builders (fixes cannot be packported)
+        # Only 3.9+ is known to pass the USAN builders (fixes cannot be backported)
         if "Usan" in name and branchname == "3.8":
+            continue
+
+        # Solaris is tested since 3.9 onward
+        if "Solaris" in name and branchname == "3.8":
             continue
 
         buildername = name + " " + branchname


### PR DESCRIPTION
This slightly updates the configuration for the Solaris worker.

There are some weird issues in Python 3.8 killing its own master connection during tests, but newer runtimes seem not to do that, so let's just skip 3.8 (we are not using anyway) and focus on those.

Also, I have a question regarding the configuration: what is the `branches` argument in worker configuration for? It seems like it's not used anywhere and doesn't have any effect (which is why I had to skip 3.8 directly in the `master.cfg` file).

Lastly, I also opened https://bugs.python.org/issue47058 that should fix/skip tests due to which the test suite is failing.
