### PR TITLE
Add new builder for win-arm64

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -198,6 +198,8 @@ def get_builders(settings):
         # Windows/arm64
         ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE),
         ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild, STABLE),
+        ("ARM64 Windows Azure", "linaro2-win-arm64", WindowsARM64Build, UNSTABLE),
+        ("ARM64 Windows Non-Debug Azure", "linaro2-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE),
     ]
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -279,5 +279,10 @@ def get_workers(settings):
             tags=['windows', 'arm64'],
             parallel_tests=4,
         ),
+        cpw(
+            name="linaro2-win-arm64",
+            tags=['windows', 'arm64'],
+            parallel_tests=2,
+        ),
 
     ]


### PR DESCRIPTION
Marked as UNSTABLE so we can fix potential errors in machine setup.

This builder is hosted on Azure and deployed by Linaro.