### PR TITLE
Disable refleak builds on ware-win81-release

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -29,6 +29,7 @@ from custom.factories import (
     CentOS9NoBuiltinHashesUnixBuild,
     CentOS9NoBuiltinHashesUnixBuildExceptBlake2,
     SlowWindowsBuild,
+    WindowsBuild,
     Windows64Build,
     Windows64RefleakBuild,
     Windows64ReleaseBuild,
@@ -134,9 +135,12 @@ def get_builders(settings):
         ("AMD64 Windows7 SP1", "kloth-win7", Windows64Build, STABLE),
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE),
         ("AMD64 Windows8.1 Non-Debug", "ware-win81-release", Windows64ReleaseBuild, STABLE),
-        ("AMD64 Windows8.1 Refleaks", "ware-win81-release", Windows64RefleakBuild, STABLE),
+        #("AMD64 Windows8.1 Refleaks", "ware-win81-release", Windows64RefleakBuild, STABLE),
         ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, STABLE),
         # -- Unstable builders --
+        # Temporary load generators for ware-win81-release
+        ("x86 Windows8.1", "ware-win81-release", WindowsBuild, UNSTABLE),
+        ("AMD64 Windows8.1", "ware-win81-release", Windows64Build, UNSTABLE),
         # Linux x86 / AMD64
         ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild, UNSTABLE),
         ("AMD64 Alpine Linux", "ware-alpine", UnixBuild, UNSTABLE),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -288,6 +288,7 @@ class PGOUnixBuild(NonDebugUnixBuild):
             self.configureFlags = self.configureFlags + ["--with-readline=edit"]
         return super().setup(parallel, branch, *args, **kwargs)
 
+
 class ClangUnixBuild(UnixBuild):
     buildersuffix = ".clang"
     configureFlags = [
@@ -397,11 +398,13 @@ class RHEL8Build(RHEL7Build):
         "--with-lto",
     ]
 
+
 class CentOS9Build(RHEL8Build):
     # Build on 64-bit CentOS Stream 9.
     # For now, it's the same as RHEL8, but later it may get different
     # options.
     pass
+
 
 class FedoraStableBuild(RHEL8Build):
     # Build Python on 64-bit Fedora Stable.
@@ -481,7 +484,7 @@ class MacOSArmWithBrewBuild(UnixBuild):
 ##############################################################################
 
 
-class WindowsBuild(TaggedBuildFactory):
+class BaseWindowsBuild(TaggedBuildFactory):
     build_command = [r"Tools\buildbot\build.bat"]
     remote_deploy_command = [r"Tools\buildbot\remoteDeploy.bat"]
     remote_pythonInfo_command = [r"Tools\buildbot\remotePythoninfo.bat"]
@@ -542,8 +545,12 @@ class WindowsBuild(TaggedBuildFactory):
         self.addStep(Clean(command=clean_command))
 
 
-class WindowsRefleakBuild(WindowsBuild):
-    buildersuffix = ".refleak"
+class WindowsBuild(BaseWindowsBuild):
+    buildersuffix = '.x32'
+
+
+class WindowsRefleakBuild(BaseWindowsBuild):
+    buildersuffix = ".x32.refleak"
     testFlags = ["-j2", "-R", "3:3", "-u-cpu"]
     # -R 3:3 is supposed to only require timeout x 6, but in practice,
     # it's much more slower. Use timeout x 10 to prevent timeout
@@ -557,7 +564,7 @@ class SlowWindowsBuild(WindowsBuild):
     testFlags = ["-j2", "-u-cpu", "-u-largefile"]
 
 
-class Windows64Build(WindowsBuild):
+class Windows64Build(BaseWindowsBuild):
     buildFlags = ["-p", "x64"]
     testFlags = ["-p", "x64", "-j2"]
     cleanFlags = ["-p", "x64"]
@@ -582,11 +589,12 @@ class Windows64ReleaseBuild(Windows64Build):
     factory_tags = ["win64", "nondebug"]
 
 
-class WindowsARM64Build(WindowsBuild):
+class WindowsARM64Build(BaseWindowsBuild):
     buildFlags = ["-p", "ARM64"]
     testFlags = ["-p", "ARM64", "-j2"]
     cleanFlags = ["-p", "ARM64"]
     factory_tags = ["win-arm64"]
+
 
 class WindowsARM64ReleaseBuild(WindowsARM64Build):
     buildersuffix = ".nondebug"


### PR DESCRIPTION
Something keeps killing this worker, and the current leading suspect is one of
the refleak builds.  It's also possible that something is going wrong with
Azure, as the worker does not recover after killing off buildbot-worker.exe and
all children.  Leaving it running for a few days without the refleak builds
should hopefully give some more information.  Azure seems to have
completely dropped all possibility of creating a new Windows 8.1 VM, so if
it turns out to still be dying without the refleak builds, it's probably going to
wind up retired.

To keep some load on the worker, temporary unstable debug mode
builders are also added for both 32 and 64 bit builds.