### PR TITLE
Add environment variable to set settings path

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -80,6 +80,7 @@ def set_up_sentry():
     log.addObserver(logToSentry)
 
 settings_path = os.path.join('/etc', 'buildbot', 'settings.yaml')
+settings_path = os.environ.get('PYBUILDBOT_SETTINGS_PATH', settings_path)
 
 try:
     settings = Settings.from_file(settings_path)


### PR DESCRIPTION
Followup from #301, the buildbot server now takes an environment variable to set where the settings file should be found, otherwise defaulting to `/etc/buildbot/settings.yaml`.