### PR TITLE
Test Emscripten with dynamic linking

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -36,7 +36,8 @@ from custom.factories import (
     MacOSArmWithBrewBuild,
     WindowsARM64Build,
     WindowsARM64ReleaseBuild,
-    Wasm32EmscriptenNodeBuild,
+    Wasm32EmscriptenNodePThreadsBuild,
+    Wasm32EmscriptenNodeDLBuild,
     Wasm32EmscriptenBrowserBuild,
     Wasm32WASIBuild,
 )
@@ -212,8 +213,9 @@ def get_builders(settings):
         ("ARM64 Windows Non-Debug Azure", "linaro2-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE, NO_TIER),
 
         # WebAssembly
-        ("wasm32-emscripten node (threaded)", "bcannon-wasm", Wasm32EmscriptenNodeBuild, UNSTABLE, NO_TIER),
-        ("wasm32-emscripten browser (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, UNSTABLE, NO_TIER),
+        ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, UNSTABLE, NO_TIER),
+        ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild, UNSTABLE, NO_TIER),
+        ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, UNSTABLE, NO_TIER),
         ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild, UNSTABLE, NO_TIER),
     ]
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -763,8 +763,10 @@ class Wasm32EmscriptenBuild(UnixCrossBuild):
     host_make_cmd = ["emmake", "make"]
 
 
-class Wasm32EmscriptenNodeBuild(Wasm32EmscriptenBuild):
-    buildersuffix = ".emscripten-node"
+class Wasm32EmscriptenNodePThreadsBuild(Wasm32EmscriptenBuild):
+    """Emscripten with pthreads, testing with NodeJS
+    """
+    buildersuffix = ".emscripten-node-pthreads"
     extra_configure_flags = [
         # don't run with --with-pydebug, Emscripten has limited stack
         "--without-pydebug",
@@ -773,8 +775,21 @@ class Wasm32EmscriptenNodeBuild(Wasm32EmscriptenBuild):
         "--enable-wasm-pthreads",
     ]
 
+class Wasm32EmscriptenNodeDLBuild(Wasm32EmscriptenBuild):
+    """Emscripten with dynamic linking, testing with NodeJS
+    """
+    buildersuffix = ".emscripten-node-dl"
+    extra_configure_flags = [
+        # don't run with --with-pydebug, Emscripten has limited stack
+        "--without-pydebug",
+        "--with-emscripten-target=node",
+        "--enable-wasm-dynamic-linking",
+        "--disable-wasm-pthreads",
+    ]
 
 class Wasm32EmscriptenBrowserBuild(Wasm32EmscriptenBuild):
+    """Emscripten browser builds (no tests)
+    """
     buildersuffix = ".emscripten-browser"
     extra_configure_flags = [
         # don't run with --with-pydebug, Emscripten has limited stack


### PR DESCRIPTION
Also test wasm32-emscripten with dynamic linking and extension module
support. Pyodide builds CPython with dynamic linking and without
threading support.