### PR TITLE
Mark WASM buildbots as stable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -213,10 +213,10 @@ def get_builders(settings):
         ("ARM64 Windows Non-Debug Azure", "linaro2-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE, NO_TIER),
 
         # WebAssembly
-        ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, UNSTABLE, NO_TIER),
-        ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild, UNSTABLE, NO_TIER),
-        ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, UNSTABLE, NO_TIER),
-        ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild, UNSTABLE, NO_TIER),
+        ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, STABLE, NO_TIER),
+        ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild, STABLE, NO_TIER),
+        ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, STABLE, NO_TIER),
+        ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild, STABLE, NO_TIER),
     ]
 
 


### PR DESCRIPTION
The wasm32-emscripten and wasm32-wasi build bots have been stable for a while. Mark them as stable.

![image](https://user-images.githubusercontent.com/444071/176959130-16136cca-4c4d-496b-95c8-fbde866d59fb.png)
