### PR TITLE
Remove ware-win81-release worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -144,8 +144,6 @@ def get_builders(settings):
         ("AMD64 Windows10 Pro", "kloth-win64", Windows64Build, STABLE, NO_TIER),
         ("AMD64 Windows7 SP1", "kloth-win7", Windows64Build, STABLE, NO_TIER),
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE, NO_TIER),
-        ("AMD64 Windows8.1 Non-Debug", "ware-win81-release", Windows64ReleaseBuild, STABLE, NO_TIER),
-        #("AMD64 Windows8.1 Refleaks", "ware-win81-release", Windows64RefleakBuild, STABLE, NO_TIER),
         ("x86 Windows7", "bolen-windows7", SlowWindowsBuild, STABLE, NO_TIER),
         # -- Unstable builders --
         # Linux x86 / AMD64

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -270,11 +270,6 @@ def get_workers(settings):
             parallel_builders=2,
         ),
         cpw(
-            name="ware-win81-release",
-            tags=['windows', 'win8', 'amd64', 'x86-64'],
-            parallel_tests=4,
-        ),
-        cpw(
             name="ware-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64'],
             parallel_tests=2,


### PR DESCRIPTION
It's not coming back at this point, replaced by ware-win11.  If at some
point I get an 8.1 worker running again, I will re-add.
