### PR TITLE
Promote WASM to tier 3, run parallel builds

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -213,10 +213,10 @@ def get_builders(settings):
         ("ARM64 Windows Non-Debug Azure", "linaro2-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE, NO_TIER),
 
         # WebAssembly
-        ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, STABLE, NO_TIER),
-        ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild, STABLE, NO_TIER),
-        ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, STABLE, NO_TIER),
-        ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild, STABLE, NO_TIER),
+        ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, STABLE, TIER_3),
+        ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild, STABLE, TIER_3),
+        ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild, STABLE, TIER_3),
+        ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild, STABLE, TIER_3),
     ]
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -294,5 +294,6 @@ def get_workers(settings):
             tags=['wasm', 'emscripten', 'wasi'],
             branches=['3.11', '3.x'],
             parallel_tests=2,
+            parallel_builders=2,
         ),
     ]


### PR DESCRIPTION
wasm32-emscripten and wasm32-wasi have been promoted to tier 3,
https://github.com/python/steering-council/issues/131

New buildbot hardware has more cores, run two build jobs in parallel.