### PR TITLE
Ensure the email formatter has the logs content

### DIFF
--- a/master/custom/email_formatter.py
+++ b/master/custom/email_formatter.py
@@ -58,6 +58,7 @@ MESSAGE_FORMATTER = CustomMessageFormatter(
     template=MAIL_TEMPLATE,
     template_type="plain",
     want_logs=True,
+    want_logs_content=True,
     want_properties=True,
     want_steps=True,
 )


### PR DESCRIPTION
We were failing to construct the email because the log content
was missing and this was making it fail to fill the template.
