### PR TITLE
Promote Raspbian to stable, disable it for 3.8.

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -176,7 +176,7 @@ def get_builders(settings):
         ("PPC64LE CentOS9 LTO", "cstratak-CentOS9-ppc64le", LTONonDebugUnixBuild, UNSTABLE, NO_TIER),
         ("PPC64LE CentOS9 LTO + PGO", "cstratak-CentOS9-ppc64le", LTOPGONonDebugBuild, UNSTABLE, NO_TIER),
         # Linux aarch32
-        ("ARM Raspbian", "gps-raspbian", SlowNonDebugUnixBuild, UNSTABLE, TIER_3),
+        ("ARM Raspbian", "gps-raspbian", SlowNonDebugUnixBuild, STABLE, TIER_3),
         # Linux aarch64
         ("aarch64 Fedora Rawhide", "cstratak-fedora-rawhide-aarch64", FedoraRawhideBuild, UNSTABLE, NO_TIER),
         ("aarch64 Fedora Rawhide Refleaks", "cstratak-fedora-rawhide-aarch64", UnixRefleakBuild, UNSTABLE, NO_TIER),

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -241,6 +241,10 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         if tier:
             tags.append(tier)
 
+        # Raspbian: test_gdb started failing on 3.8 in early 2022.
+        if "raspbian" in tags and branchname in {"3.8"}:
+            continue
+
         # Only 3.11+ for WebAssembly builds
         if "wasm" in tags and branchname in {"3.8", "3.9", "3.10"}:
             continue


### PR DESCRIPTION
Disables it for the 3.8 branch as infrastructure changes early this year make `test_gdb` fail in that old branch; not important.

The bot lives on my home network which has battery backup but single source of failure connectivity and long term power outages would still be an issue. If it ever becomes a problem, we can demote it.