### PR TITLE
Reduce ware-gentoo-x86 to 1 build at a time

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -267,7 +267,6 @@ def get_workers(settings):
         cpw(
             name="ware-gentoo-x86",
             tags=['linux', 'unix', 'gentoo', 'x86'],
-            parallel_builders=2,
         ),
         cpw(
             name="ware-win11",


### PR DESCRIPTION
That's really all it can handle anymore.