### PR TITLE
Decrease parallelism on ambv-bb-win11

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -284,6 +284,7 @@ def get_workers(settings):
         cpw(
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
+            branches=['3.x'],
             parallel_tests=3,
         ),
     ]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -284,6 +284,6 @@ def get_workers(settings):
         cpw(
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
-            parallel_tests=8,
+            parallel_tests=3,
         ),
     ]


### PR DESCRIPTION
It turns out that regrtest isn't very smart and -M24g -j8 meant a possible peak of 24GB times 8 = 192 GB RAM, which is more than the host of this VM physically has.