### PR TITLE
Increase test timeout because test_bigmem can be a real hog

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -561,7 +561,7 @@ class Windows64BigmemBuild(BaseWindowsBuild):
     buildersuffix = ".bigmem"
     buildFlags = ["-p", "x64"]
     testFlags = ["-p", "x64", "-M24g", "-uall"]
-    test_timeout = TEST_TIMEOUT * 2
+    test_timeout = TEST_TIMEOUT * 4
     cleanFlags = ["-p", "x64"]
     factory_tags = ["win64", "bigmem"]
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -285,6 +285,6 @@ def get_workers(settings):
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
             branches=['3.x'],
-            parallel_tests=3,
+            parallel_tests=4,
         ),
     ]


### PR DESCRIPTION
Also, slightly increase parallelism based on performance of the previous runs.