### PR TITLE
Remove secondary builder for win-arm64

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -209,8 +209,6 @@ def get_builders(settings):
         # Windows/arm64
         ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE, TIER_3),
         ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild, STABLE, NO_TIER),
-        ("ARM64 Windows Azure", "linaro2-win-arm64", WindowsARM64Build, UNSTABLE, NO_TIER),
-        ("ARM64 Windows Non-Debug Azure", "linaro2-win-arm64", WindowsARM64ReleaseBuild, UNSTABLE, NO_TIER),
 
         # WebAssembly
         ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild, STABLE, TIER_3),

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -270,11 +270,6 @@ def get_workers(settings):
             parallel_tests=4,
         ),
         cpw(
-            name="linaro2-win-arm64",
-            tags=['windows', 'arm64'],
-            parallel_tests=2,
-        ),
-        cpw(
             name="bcannon-wasm",
             tags=['wasm', 'emscripten', 'wasi'],
             branches=['3.11', '3.x'],


### PR DESCRIPTION
We decided to remove that second builder, that was too unstable to be used.

Can you remove credentials associated to it too?
Thanks