### PR TITLE
Implement comment-based commands for triggering buildbots and new labels

### DIFF
--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -1,4 +1,5 @@
 # Functions to enable buildbot to test pull requests and report back
+import re
 import logging
 
 from dateutil.parser import parse as dateparse
@@ -10,14 +11,26 @@ from buildbot.util import httpclientservice
 from buildbot.www.hooks.github import GitHubEventHandler
 
 TESTING_LABEL = ":hammer: test-with-buildbots"
+REFLEAK_TESTING_LABEL = ":hammer: test-with-refleak-buildbots"
 
 GITHUB_PROPERTIES_WHITELIST = ["*.labels"]
 
 BUILD_SCHEDULED_MESSAGE = f"""\
 :robot: New build scheduled with the buildbot fleet by @{{user}} for commit {{commit}} :robot:
 
-If you want to schedule another build, you need to add the "{TESTING_LABEL}" label again.
+If you want to schedule another build, you need to add the `{{label}}` label again.
 """
+
+BUILD_COMMAND_SCHEDULED_MESSAGE = f"""\
+:robot: New build scheduled with the buildbot fleet by @{{user}} for commit {{commit}} :robot:
+
+The command will test the builders whose names match following regular expression: `{{filter}}`
+
+The builders matched are:
+{{builders}}
+"""
+
+BUILDBOT_COMMAND = re.compile(r"!buildbot (.+)")
 
 
 def should_pr_be_tested(change):
@@ -25,8 +38,31 @@ def should_pr_be_tested(change):
 
 
 class CustomGitHubEventHandler(GitHubEventHandler):
+    def __init__(self, *args, builder_names, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.builder_names = builder_names
+
     @defer.inlineCallbacks
-    def _remove_label_and_comment(self, payload):
+    def _post_comment(self, comments_url, comment):
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            headers["Authorization"] = "token " + self._token
+
+        http = yield httpclientservice.HTTPClientService.getService(
+            self.master,
+            self.github_api_endpoint,
+            headers=headers,
+            debug=self.debug,
+            verify=self.verify,
+        )
+
+        yield http.post(
+            comments_url.replace(self.github_api_endpoint, ""),
+            json={"body": comment},
+        )
+
+    @defer.inlineCallbacks
+    def _remove_label_and_comment(self, payload, label):
         headers = {"User-Agent": "Buildbot"}
         if self._token:
             headers["Authorization"] = "token " + self._token
@@ -45,22 +81,216 @@ class CustomGitHubEventHandler(GitHubEventHandler):
         commit = payload["pull_request"]["head"]["sha"]
         yield http.post(
             url.replace(self.github_api_endpoint, ""),
-            json={"body": BUILD_SCHEDULED_MESSAGE.format(user=username, commit=commit)},
+            json={
+                "body": BUILD_SCHEDULED_MESSAGE.format(
+                    user=username, commit=commit, label=label
+                )
+            },
         )
 
         # Remove the label
-        url = payload["pull_request"]["issue_url"] + f"/labels/{TESTING_LABEL}"
+        url = payload["pull_request"]["issue_url"] + f"/labels/{label}"
         yield http.delete(url.replace(self.github_api_endpoint, ""))
 
     @defer.inlineCallbacks
+    def _get_pull_request(self, url):
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            headers["Authorization"] = "token " + self._token
+
+        http = yield httpclientservice.HTTPClientService.getService(
+            self.master,
+            self.github_api_endpoint,
+            headers=headers,
+            debug=self.debug,
+            verify=self.verify,
+        )
+        res = yield http.get(url)
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            return data
+
+        log.msg(f"Failed fetching PR from {url}: response code {res.code}")
+        return None
+
+    @defer.inlineCallbacks
+    def _user_has_write_permissions(self, payload, user):
+        """Check if *user* has write permissions"""
+
+        repo = payload["repository"]["full_name"]
+        url = f"https://api.github.com/repos/{repo}/collaborators/{user}/permission"
+        headers = {"User-Agent": "Buildbot"}
+        if self._token:
+            headers["Authorization"] = "token " + self._token
+        http = yield httpclientservice.HTTPClientService.getService(
+            self.master,
+            self.github_api_endpoint,
+            headers=headers,
+            debug=self.debug,
+            verify=self.verify,
+        )
+        res = yield http.get(url)
+        if 200 <= res.code < 300:
+            data = yield res.json()
+            log.msg(f"User {user} has permission {data['permission']} on {repo}")
+            return data["permission"] in {"admin", "write"}
+
+        log.msg(
+            f"Failed fetching user permissions from {url}: response code {res.code}"
+        )
+        return False
+
+    def _get_changes_from_pull_request(
+        self, changes, pr_number, payload, pull_request, event, builder_filter
+    ):
+        refname = "refs/pull/{}/{}".format(pr_number, self.pullrequest_ref)
+        basename = pull_request["base"]["ref"]
+        commits = pull_request["commits"]
+        title = pull_request["title"]
+        comments = pull_request["body"]
+        properties = self.extractProperties(pull_request)
+        properties.update({"should_test_pr": True})
+        properties.update({"event": event})
+        properties.update({"basename": basename})
+        properties.update({"builderfilter": builder_filter})
+        change = {
+            "revision": pull_request["head"]["sha"],
+            "when_timestamp": dateparse(pull_request["created_at"]),
+            "branch": refname,
+            "revlink": pull_request["_links"]["html"]["href"],
+            "repository": payload["repository"]["html_url"],
+            "project": pull_request["base"]["repo"]["full_name"],
+            "category": "pull",
+            "author": payload["sender"]["login"],
+            "comments": "GitHub Pull Request #{0} ({1} commit{2})\n{3}\n{4}".format(
+                pr_number, commits, "s" if commits != 1 else "", title, comments
+            ),
+            "properties": properties,
+        }
+
+        if callable(self._codebase):
+            change["codebase"] = self._codebase(payload)
+        elif self._codebase is not None:
+            change["codebase"] = self._codebase
+
+        changes.append(change)
+
+        log.msg(
+            "Received {} changes from GitHub PR #{}".format(len(changes), pr_number)
+        )
+        return (changes, "git")
+
+    @defer.inlineCallbacks
+    def handle_issue_comment(self, payload, event):
+        changes = []
+        number = payload["issue"]["number"]
+        action = payload.get("action")
+
+        # We only care about new comments
+        if action != "created":
+            log.msg(
+                "GitHub PR #{} comment action is not 'created', ignoring".format(number)
+            )
+            return (changes, "git")
+
+        # We only care about comments on PRs, not issues.
+        if "pull_request" not in payload["issue"]:
+            log.msg("GitHub PR #{} is not a pull request, ignoring".format(number))
+            return (changes, "git")
+
+        comment = payload["comment"]["body"].strip()
+
+        match = BUILDBOT_COMMAND.match(comment)
+        # If the comment is not a buildbot command, ignore it
+        if not match:
+            log.msg(
+                "GitHub PR #{} comment is not a buildbot command, ignoring".format(
+                    number
+                )
+            )
+            return (changes, "git")
+
+        builder_filter = match.group(1).strip()
+
+        # If the command is empty, ignore it
+        if not builder_filter:
+            log.msg("GitHub PR #{} command is empty, ignoring".format(number))
+            return (changes, "git")
+
+        # If the command is not from a user with write permissions, ignore it
+        if not (
+            yield self._user_has_write_permissions(payload, payload["sender"]["login"])
+        ):
+            log.msg(
+                "GitHub PR #{} user {} has no write permissions, ignoring".format(
+                    number, payload["sender"]["login"]
+                )
+            )
+            yield self._post_comment(
+                payload["issue"]["comments_url"],
+                "You don't have write permissions to trigger a build",
+            )
+            return (changes, "git")
+
+        pull_url = payload["issue"]["pull_request"]["url"]
+
+        # We need to fetch the PR data from GitHub because the payload doesn't
+        # contain a lot of information we need.
+        pull_request = yield self._get_pull_request(pull_url)
+        if pull_request is None:
+            log.msg("Failed to fetch PR #{} from {}".format(number, pull_url))
+            return (changes, "git")
+
+        repo_full_name = payload["repository"]["full_name"]
+        head_sha = pull_request["head"]["sha"]
+
+        log.msg("Processing GitHub PR #{}".format(number), logLevel=logging.DEBUG)
+
+        head_msg = yield self._get_commit_msg(repo_full_name, head_sha)
+        if self._has_skip(head_msg):
+            log.msg(
+                "GitHub PR #{}, Ignoring: "
+                "head commit message contains skip pattern".format(number)
+            )
+            return ([], "git")
+
+        builder_filter_fn = re.compile(builder_filter)
+        yield self._post_comment(
+            payload["issue"]["comments_url"],
+            BUILD_COMMAND_SCHEDULED_MESSAGE.format(
+                user=payload["sender"]["login"],
+                commit=head_sha,
+                filter=builder_filter,
+                builders="\n".join(
+                    {
+                        f"- `{builder}`"
+                        for builder in self.builder_names
+                        if builder_filter_fn.match(builder)
+                    }
+                ),
+            ),
+        )
+
+        return self._get_changes_from_pull_request(
+            changes, number, payload, pull_request, event, builder_filter
+        )
+
+    @defer.inlineCallbacks
     def handle_pull_request(self, payload, event):
+
         changes = []
         number = payload["number"]
-        refname = "refs/pull/{}/{}".format(number, self.pullrequest_ref)
-        basename = payload["pull_request"]["base"]["ref"]
-        commits = payload["pull_request"]["commits"]
-        title = payload["pull_request"]["title"]
-        comments = payload["pull_request"]["body"]
+        action = payload.get("action")
+
+        if action != "labeled":
+            log.msg("GitHub PR #{} {}, ignoring".format(number, action))
+            return (changes, "git")
+
+        label = payload.get("label")["name"]
+        if label not in {TESTING_LABEL, REFLEAK_TESTING_LABEL}:
+            log.msg("Invalid label in PR #{}, ignoring".format(number))
+            return (changes, "git")
+
         repo_full_name = payload["repository"]["full_name"]
         head_sha = payload["pull_request"]["head"]["sha"]
 
@@ -74,42 +304,14 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             )
             return ([], "git")
 
-        action = payload.get("action")
-        if action != "labeled":
-            log.msg("GitHub PR #{} {}, ignoring".format(number, action))
-            return (changes, "git")
+        yield self._remove_label_and_comment(payload, label)
 
-        if payload.get("label")["name"] != TESTING_LABEL:
-            log.msg("Invalid label in PR #{}, ignoring".format(number))
-            return (changes, "git")
+        builder_filter = ""
+        if label == TESTING_LABEL:
+            builder_filter = ".*"
+        elif label == REFLEAK_TESTING_LABEL:
+            builder_filter = ".*Refleaks.*"
 
-        yield self._remove_label_and_comment(payload)
-
-        properties = self.extractProperties(payload["pull_request"])
-        properties.update({"should_test_pr": True})
-        properties.update({"event": event})
-        properties.update({"basename": basename})
-        change = {
-            "revision": payload["pull_request"]["head"]["sha"],
-            "when_timestamp": dateparse(payload["pull_request"]["created_at"]),
-            "branch": refname,
-            "revlink": payload["pull_request"]["_links"]["html"]["href"],
-            "repository": payload["repository"]["html_url"],
-            "project": payload["pull_request"]["base"]["repo"]["full_name"],
-            "category": "pull",
-            "author": payload["sender"]["login"],
-            "comments": "GitHub Pull Request #{0} ({1} commit{2})\n{3}\n{4}".format(
-                number, commits, "s" if commits != 1 else "", title, comments
-            ),
-            "properties": properties,
-        }
-
-        if callable(self._codebase):
-            change["codebase"] = self._codebase(payload)
-        elif self._codebase is not None:
-            change["codebase"] = self._codebase
-
-        changes.append(change)
-
-        log.msg("Received {} changes from GitHub PR #{}".format(len(changes), number))
-        return (changes, "git")
+        return self._get_changes_from_pull_request(
+            changes, number, payload, payload["pull_request"], event, builder_filter
+        )

--- a/master/custom/schedulers.py
+++ b/master/custom/schedulers.py
@@ -1,0 +1,38 @@
+import re
+from buildbot.schedulers.basic import AnyBranchScheduler
+from twisted.internet import defer
+from twisted.python import log
+
+
+class GitHubPrScheduler(AnyBranchScheduler):
+    @defer.inlineCallbacks
+    def addBuildsetForChanges(self, **kwargs):
+        log.msg("Preapring buildset for PR changes")
+        changeids = kwargs.get("changeids")
+        if changeids is None or len(changeids) != 1:
+            log.msg("No changeids or more than one changeid found")
+            yield super().addBuildsetForChanges(**kwargs)
+            return
+
+        changeid = changeids[0]
+        chdict = yield self.master.db.changes.getChange(changeid)
+
+        builder_filter = chdict["properties"].get("builderfilter", None)
+        builder_names = kwargs.get("builderNames", self.builderNames)
+        if builder_filter and builder_names:
+            log.msg("Found builder filter: {}".format(builder_filter))
+            builder_filter, _ = builder_filter
+            matcher = re.compile(builder_filter)
+            builder_names = [
+                builder_name
+                for builder_name in builder_names
+                if matcher.match(builder_name)
+            ]
+            log.msg("Bulder names filtered: {}".format(builder_names))
+            kwargs.update(builderNames=builder_names)
+            yield super().addBuildsetForChanges(**kwargs)
+            return
+
+        log.msg("Scheduling regular non-filtered buildset")
+        yield super().addBuildsetForChanges(**kwargs)
+        return

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -15,6 +15,7 @@ import subprocess
 import sys
 
 from datetime import timedelta
+from functools import partial
 
 from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
@@ -50,6 +51,7 @@ from custom.pr_testing import (
 from custom.settings import Settings  # noqa: E402
 from custom.steps import Git, GitHub  # noqa: E402
 from custom.workers import get_workers  # noqa: E402
+from custom.schedulers import GitHubPrScheduler # noqa: E402
 from custom.release_dashboard import get_release_status_app    # noqa: E402
 from custom.builders import (
     get_builders,
@@ -336,7 +338,7 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     )
 
 c["schedulers"].append(
-    AnyBranchScheduler(
+    GitHubPrScheduler(
         name="pull-request-scheduler",
         change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
         treeStableTimer=30,  # seconds
@@ -382,7 +384,10 @@ c["www"] = dict(
     authz=AUTHZ,
     change_hook_dialects={
         "github": {
-            "class": CustomGitHubEventHandler,
+            "class": partial(
+                CustomGitHubEventHandler,
+                builder_names=pull_request_builders
+            ),
             "secret": str(settings.github_change_hook_secret),
             "strict": True,
             "token": settings.github_status_token,


### PR DESCRIPTION
This commit implements the following:

- A new comment-based way to trigger specific buildbots based on regular
  expressions that will be tested against builder names.
- A new label to trigger specifically refleak builders.
