### PR TITLE
Make Bedevere showing label names like GitHub does

### DIFF
--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -18,7 +18,7 @@ GITHUB_PROPERTIES_WHITELIST = ["*.labels"]
 BUILD_SCHEDULED_MESSAGE = f"""\
 :robot: New build scheduled with the buildbot fleet by @{{user}} for commit {{commit}} :robot:
 
-If you want to schedule another build, you need to add the `{{label}}` label again.
+If you want to schedule another build, you need to add the <kbd>{{label}}</kbd> label again.
 """
 
 BUILD_COMMAND_SCHEDULED_MESSAGE = f"""\
@@ -35,11 +35,6 @@ BUILDBOT_COMMAND = re.compile(r"!buildbot (.+)")
 
 def should_pr_be_tested(change):
     return change.properties.getProperty("should_test_pr", False)
-
-
-def emote(markup_text):
-    """Manually replace some GitHub emoji markup with Unicode emojis."""
-    return markup_text.replace(':hammer:', '🔨')
 
 
 class CustomGitHubEventHandler(GitHubEventHandler):
@@ -88,7 +83,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             url.replace(self.github_api_endpoint, ""),
             json={
                 "body": BUILD_SCHEDULED_MESSAGE.format(
-                    user=username, commit=commit, label=emote(label)
+                    user=username, commit=commit, label=label
                 )
             },
         )

--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -38,7 +38,7 @@ def should_pr_be_tested(change):
 
 
 def emote(markup_text):
-    """Manually replace some GitHub emoji markup with Unicode .emojis"""
+    """Manually replace some GitHub emoji markup with Unicode emojis."""
     return markup_text.replace(':hammer:', '🔨')
 
 

--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -37,6 +37,11 @@ def should_pr_be_tested(change):
     return change.properties.getProperty("should_test_pr", False)
 
 
+def emote(markup_text):
+    """Manually replace some GitHub emoji markup with Unicode .emojis"""
+    return markup_text.replace(':hammer:', '🔨')
+
+
 class CustomGitHubEventHandler(GitHubEventHandler):
     def __init__(self, *args, builder_names, **kwargs):
         super().__init__(*args, **kwargs)
@@ -83,7 +88,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             url.replace(self.github_api_endpoint, ""),
             json={
                 "body": BUILD_SCHEDULED_MESSAGE.format(
-                    user=username, commit=commit, label=label
+                    user=username, commit=commit, label=emote(label)
                 )
             },
         )


### PR DESCRIPTION
Currently Bedevere [prints raw label names](https://github.com/python/cpython/pull/101748#issuecomment-1424532890):

![](https://user-images.githubusercontent.com/4881073/218042407-559422cd-6029-44b9-ab5d-7067ec45cdd5.png)

Note that a label is spelled as raw `:hammer: test-with-refleak-buildbots`. However, the label selector shows it differently:

![](https://user-images.githubusercontent.com/4881073/218042940-7ae29d47-99dd-4949-a095-f1fff2bbef52.png)

This PR fixed the raw output of code blocks with a manual rendering of this exact emoticon. Thanks to it the message will look like this (simulated with Chrome Developer Tools):

![](https://user-images.githubusercontent.com/4881073/218043997-59e13b74-6b22-421d-8080-f64e7f8d2087.png)
