### PR TITLE
Remove kloth-win11 and kloth-win64 workers

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -142,10 +142,8 @@ def get_builders(settings):
         ("AMD64 FreeBSD Non-Debug", "koobs-freebsd-9e36", SlowNonDebugUnixBuild, STABLE, TIER_3),
         ("AMD64 FreeBSD Shared", "koobs-freebsd-564d", SlowSharedUnixBuild, STABLE, NO_TIER),
         # Windows
-        ("AMD64 Windows10 Pro", "kloth-win64", Windows64Build, STABLE, NO_TIER),
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE, NO_TIER),
         ("AMD64 Windows11 Bigmem", "ambv-bb-win11", Windows64BigmemBuild, STABLE, NO_TIER),
-        ("AMD64 Windows11", "kloth-win11", Windows64Build, UNSTABLE, NO_TIER),
         ("AMD64 Windows11 Non-Debug", "ware-win11", Windows64ReleaseBuild, STABLE, NO_TIER),
         ("AMD64 Windows11 Refleaks", "ware-win11", Windows64RefleakBuild, STABLE, NO_TIER),
         # -- Unstable builders --

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -210,16 +210,6 @@ def get_workers(settings):
             parallel_tests=3,
         ),
         cpw(
-            name="kloth-win11",
-            tags=['windows', 'win11', 'amd64', 'x86-64'],
-            parallel_tests=40,
-        ),
-        cpw(
-            name="kloth-win64",
-            tags=['windows', 'win10', 'amd64', 'x86-64'],
-            parallel_tests=8,
-        ),
-        cpw(
             name="koobs-freebsd-9e36",
             tags=['bsd', 'unix', 'freebsd', 'amd64', 'x86-64'],
             parallel_tests=4,


### PR DESCRIPTION
They served long and faithfully, but haven't yet returned.

They'll be welcomed back if ever they reappear :)
