### PR TITLE
Remove koobs-freebsd-9e36 and koobs-freebsd-564d workers

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -138,9 +138,6 @@ def get_builders(settings):
         # macOS
         ("x86-64 macOS", "billenstein-macos", UnixBuild, STABLE, NO_TIER),
         ("ARM64 macOS", "pablogsal-macos-m1", MacOSArmWithBrewBuild, STABLE, TIER_2),
-        # Other Unix
-        ("AMD64 FreeBSD Non-Debug", "koobs-freebsd-9e36", SlowNonDebugUnixBuild, STABLE, TIER_3),
-        ("AMD64 FreeBSD Shared", "koobs-freebsd-564d", SlowSharedUnixBuild, STABLE, NO_TIER),
         # Windows
         ("AMD64 Windows10", "bolen-windows10", Windows64Build, STABLE, NO_TIER),
         ("AMD64 Windows11 Bigmem", "ambv-bb-win11", Windows64BigmemBuild, STABLE, NO_TIER),

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -212,16 +212,6 @@ def get_workers(settings):
             parallel_tests=3,
         ),
         cpw(
-            name="koobs-freebsd-9e36",
-            tags=['bsd', 'unix', 'freebsd', 'amd64', 'x86-64'],
-            parallel_tests=4,
-        ),
-        cpw(
-            name="koobs-freebsd-564d",
-            tags=['bsd', 'unix', 'freebsd', 'amd64', 'x86-64'],
-            parallel_tests=4,
-        ),
-        cpw(
             name="kulikjak-solaris-sparcv9",
             tags=['solaris', 'unix', 'sparc', 'sparcv9'],
             parallel_tests=16,


### PR DESCRIPTION
With many thanks for years of faithful service.

Should they be able to return in the future, they will be welcomed back :)
