### PR TITLE
gh-392: Add Windows NoGIL builder & worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -31,6 +31,7 @@ from custom.factories import (
     CentOS9NoBuiltinHashesUnixBuildExceptBlake2,
     Windows64Build,
     Windows64BigmemBuild,
+    Windows64NoGilBuild,
     Windows64RefleakBuild,
     Windows64ReleaseBuild,
     MacOSArmWithBrewBuild,
@@ -204,6 +205,9 @@ def get_builders(settings):
         # XXX: to be TIER_3 when stabilized
         ("AMD64 FreeBSD", "ware-freebsd", UnixBuild, UNSTABLE, NO_TIER),
         ("SPARCv9 Oracle Solaris 11.4", "kulikjak-solaris-sparcv9", UnixBuild, UNSTABLE, NO_TIER),
+
+        # Windows/amd64
+        ("AMD64 Windows Server 2022 NoGIL", "itamaro-win64-srv-22-aws", Windows64NoGilBuild, UNSTABLE, NO_TIER),
 
         # Windows/arm64
         ("ARM64 Windows", "linaro-win-arm64", WindowsARM64Build, STABLE, TIER_3),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -612,6 +612,12 @@ class Windows64ReleaseBuild(Windows64Build):
     factory_tags = ["win64", "nondebug"]
 
 
+class Windows64NoGilBuild(Windows64Build):
+    buildersuffix = '.x64.nogil'
+    buildFlags = ["-p", "x64", "--disable-gil"]
+    factory_tags = ["win64", "nogil"]
+
+
 class WindowsARM64Build(BaseWindowsBuild):
     buildFlags = ["-p", "ARM64"]
     testFlags = ["-p", "ARM64", "-j2"]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -278,4 +278,11 @@ def get_workers(settings):
             parallel_tests=2,
             parallel_builders=2,
         ),
+        cpw(
+            name="itamaro-win64-srv-22-aws",
+            tags=['windows', 'win-srv-22', 'amd64', 'x86-64'],
+            not_branches=['3.9', '3.10', '3.11', '3.12'],
+            parallel_tests=2,
+            parallel_builders=2,
+        ),
     ]


### PR DESCRIPTION
Add an AWS AMD64 Windows buildbot worker
Add a NoGIL Windows build factory
Add a NoGIL Windows builder to the newly added AWS Windows worker

fixes #392