### PR TITLE
gh-419: Allow unstable builders to trigger on PRs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -313,8 +313,7 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     if any(pattern in buildername for pattern in NO_NOTIFICATION):
         continue
 
-    if stability == STABLE:
-        stable_pull_request_builders.append(buildername)
+    stable_pull_request_builders.append(buildername)
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -306,14 +306,15 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
 
     buildername = name + " " + "PR"
 
+    if stability != STABLE:
+        unstable_pull_request_builders.append(buildername)
+        continue
+
     if any(pattern in buildername for pattern in NO_NOTIFICATION):
         continue
 
     if stability == STABLE:
         stable_pull_request_builders.append(buildername)
-    else:
-        unstable_pull_request_builders.append(buildername)
-        continue
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -294,12 +294,10 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
 
 # Set up Pull Request builders
 
-pull_request_builders = []
+stable_pull_request_builders = []
+unstable_pull_request_builders = []
 
 for name, worker_name, buildfactory, stability, tier in BUILDERS:
-    if stability != STABLE:
-        continue
-
     if "Windows XP" in name or "VS9.0" in name:
         continue
     # bpo-39911: Python 3.9 dropped Windows 7 support
@@ -311,7 +309,11 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     if any(pattern in buildername for pattern in NO_NOTIFICATION):
         continue
 
-    pull_request_builders.append(buildername)
+    if stability == STABLE:
+        stable_pull_request_builders.append(buildername)
+    else:
+        unstable_pull_request_builders.append(buildername)
+        continue
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 
@@ -345,7 +347,7 @@ c["schedulers"].append(
         name="pull-request-scheduler",
         change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
         treeStableTimer=30,  # seconds
-        builderNames=pull_request_builders,
+        builderNames=stable_pull_request_builders,
     )
 )
 
@@ -389,7 +391,7 @@ c["www"] = dict(
         "github": {
             "class": partial(
                 CustomGitHubEventHandler,
-                builder_names=pull_request_builders
+                builder_names=stable_pull_request_builders + unstable_pull_request_builders,
             ),
             "secret": str(settings.github_change_hook_secret),
             "strict": True,
@@ -453,7 +455,7 @@ c["services"].append(
     reporters.GitHubStatusPush(
         str(settings.github_status_token),
         generators=[
-            BuildStartEndStatusGenerator(builders=github_status_builders + pull_request_builders),
+            BuildStartEndStatusGenerator(builders=github_status_builders + stable_pull_request_builders),
         ],
         verbose=bool(settings.verbosity),
     )


### PR DESCRIPTION
This intention of this PR is to make it possible to *manually trigger* also unstable buildbots on PRs using the `!buildbot` command (and labels).

The lists of "PR builders" are used in several places where I kept it to *only* stable PR builders, because those other places didn't seem related to the manual triggering of buildbots on PRs.