### PR TITLE
Update itamaro workers configuration

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -202,7 +202,6 @@ UNSTABLE_BUILDERS_TIER_1 = [
     ("AMD64 Fedora Rawhide LTO", "cstratak-fedora-rawhide-x86_64", LTONonDebugUnixBuild),
     ("AMD64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-x86_64", LTOPGONonDebugBuild),
 
-    ("AMD64 Fedora NoGIL", "itamaro-fedora-x1", UnixNoGilBuild),
     ("AMD64 Ubuntu NoGIL", "itamaro-ubuntu-aws", UnixNoGilBuild),
     ("AMD64 Ubuntu NoGIL Refleaks", "itamaro-ubuntu-aws", UnixNoGilRefleakBuild),
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -280,27 +280,23 @@ def get_workers(settings):
             parallel_tests=4,
         ),
         cpw(
-            name="itamaro-fedora-x1",
-            tags=['linux', 'unix', 'fedora', 'amd64', 'x86-64'],
-            not_branches=['3.9', '3.10', '3.11', '3.12'],
-        ),
-        cpw(
             name="itamaro-ubuntu-aws",
             tags=['linux', 'unix', 'ubuntu', 'amd64', 'x86-64'],
             not_branches=['3.9', '3.10', '3.11', '3.12'],
-            parallel_tests=2,
+            parallel_tests=10,
             parallel_builders=2,
         ),
         cpw(
             name="itamaro-win64-srv-22-aws",
             tags=['windows', 'win-srv-22', 'amd64', 'x86-64'],
             not_branches=['3.9', '3.10', '3.11', '3.12'],
-            parallel_tests=2,
+            parallel_tests=10,
             parallel_builders=2,
         ),
         cpw(
             name="itamaro-macos-intel-aws",
             tags=['macOS', 'unix', 'amd64', 'x86-64'],
+            not_branches=['3.9', '3.10', '3.11', '3.12'],
             parallel_tests=10,
         ),
     ]


### PR DESCRIPTION
1. Remove the fedora worker - with the AWS-hosted ubuntu worker, better stop relying on a laptop running in my home-office
2. Increase parallel tests for the ubuntu and Windows workers
3. Add missing branch exclusions to the MacOS worker