### PR TITLE
GH-419: Pass unstable builders also into GitHubPrScheduler

### DIFF
--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -10,6 +10,8 @@ from twisted.python import log
 from buildbot.util import httpclientservice
 from buildbot.www.hooks.github import GitHubEventHandler
 
+from .builders import STABLE
+
 TESTING_LABEL = ":hammer: test-with-buildbots"
 REFLEAK_TESTING_LABEL = ":hammer: test-with-refleak-buildbots"
 
@@ -322,10 +324,11 @@ class CustomGitHubEventHandler(GitHubEventHandler):
         yield self._remove_label_and_comment(payload, label)
 
         builder_filter = ""
+        # label-based buildbots are limited to stable builders
         if label == TESTING_LABEL:
-            builder_filter = ".*"
+            builder_filter = f".* {STABLE}.*"
         elif label == REFLEAK_TESTING_LABEL:
-            builder_filter = ".*Refleaks.*"
+            builder_filter = f".*Refleaks.* {STABLE}.*"
 
         return self._get_changes_from_pull_request(
             changes, number, payload, payload["pull_request"], event, builder_filter

--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -10,8 +10,6 @@ from twisted.python import log
 from buildbot.util import httpclientservice
 from buildbot.www.hooks.github import GitHubEventHandler
 
-from .builders import STABLE
-
 TESTING_LABEL = ":hammer: test-with-buildbots"
 REFLEAK_TESTING_LABEL = ":hammer: test-with-refleak-buildbots"
 
@@ -324,11 +322,10 @@ class CustomGitHubEventHandler(GitHubEventHandler):
         yield self._remove_label_and_comment(payload, label)
 
         builder_filter = ""
-        # label-based buildbots are limited to stable builders
         if label == TESTING_LABEL:
-            builder_filter = f".* {STABLE}.*"
+            builder_filter = ".*"
         elif label == REFLEAK_TESTING_LABEL:
-            builder_filter = f".*Refleaks.* {STABLE}.*"
+            builder_filter = ".*Refleaks.*"
 
         return self._get_changes_from_pull_request(
             changes, number, payload, payload["pull_request"], event, builder_filter

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -309,13 +309,12 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     if "Windows7" in name:
         continue
 
-    buildername = name + " " + "PR"
+    buildername = f"{name} {stability} PR"
 
-    if stability != STABLE:
-        unstable_pull_request_builders.append(buildername)
-    else:
+    if stability == STABLE:
         stable_pull_request_builders.append(buildername)
-
+    else:
+        unstable_pull_request_builders.append(buildername)
 
     if any(pattern in buildername for pattern in NO_NOTIFICATION):
         continue
@@ -352,7 +351,7 @@ c["schedulers"].append(
         name="pull-request-scheduler",
         change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
         treeStableTimer=30,  # seconds
-        builderNames=stable_pull_request_builders,
+        builderNames=stable_pull_request_builders + unstable_pull_request_builders,
     )
 )
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -311,9 +311,6 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
 
     buildername = f"{name} PR"
 
-    if any(pattern in buildername for pattern in NO_NOTIFICATION):
-        continue
-
     if stability == STABLE:
         stable_pull_request_builders.append(buildername)
     else:

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -309,15 +309,15 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     if "Windows7" in name:
         continue
 
-    buildername = f"{name} {stability} PR"
+    buildername = f"{name} PR"
+
+    if any(pattern in buildername for pattern in NO_NOTIFICATION):
+        continue
 
     if stability == STABLE:
         stable_pull_request_builders.append(buildername)
     else:
         unstable_pull_request_builders.append(buildername)
-
-    if any(pattern in buildername for pattern in NO_NOTIFICATION):
-        continue
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 
@@ -352,6 +352,7 @@ c["schedulers"].append(
         change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
         treeStableTimer=30,  # seconds
         builderNames=stable_pull_request_builders + unstable_pull_request_builders,
+        stable_builder_names=set(stable_pull_request_builders),
     )
 )
 


### PR DESCRIPTION
This is needed to support triggering unstable builders using `!buildbot` PR comment

Pass `GitHubPrScheduler` a set of "known stable builders" to it can avoid triggering unstable builders unless it's a comment-based trigger