### PR TITLE
GH-419: Allow unstable builders on GitHub PR Checks

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -300,7 +300,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
 # Set up Pull Request builders
 
 stable_pull_request_builders = []
-unstable_pull_request_builders = []
+all_pull_request_builders = []
 
 for name, worker_name, buildfactory, stability, tier in BUILDERS:
     if "Windows XP" in name or "VS9.0" in name:
@@ -310,11 +310,9 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
         continue
 
     buildername = f"{name} PR"
-
+    all_pull_request_builders.append(buildername)
     if stability == STABLE:
         stable_pull_request_builders.append(buildername)
-    else:
-        unstable_pull_request_builders.append(buildername)
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 
@@ -348,7 +346,7 @@ c["schedulers"].append(
         name="pull-request-scheduler",
         change_filter=util.ChangeFilter(filter_fn=should_pr_be_tested),
         treeStableTimer=30,  # seconds
-        builderNames=stable_pull_request_builders + unstable_pull_request_builders,
+        builderNames=all_pull_request_builders,
         stable_builder_names=set(stable_pull_request_builders),
     )
 )
@@ -393,7 +391,7 @@ c["www"] = dict(
         "github": {
             "class": partial(
                 CustomGitHubEventHandler,
-                builder_names=stable_pull_request_builders + unstable_pull_request_builders,
+                builder_names=all_pull_request_builders,
             ),
             "secret": str(settings.github_change_hook_secret),
             "strict": True,
@@ -457,7 +455,7 @@ c["services"].append(
     reporters.GitHubStatusPush(
         str(settings.github_status_token),
         generators=[
-            BuildStartEndStatusGenerator(builders=github_status_builders + stable_pull_request_builders),
+            BuildStartEndStatusGenerator(builders=github_status_builders + all_pull_request_builders),
         ],
         verbose=bool(settings.verbosity),
     )


### PR DESCRIPTION
With GH-436 the builders are finally triggered correctly!
But they don't show up in the GitHub checks status thingie. To have these builders show up in GitHub, we need to add them to the `GitHubStatusPush` reporter.