### PR TITLE
Add `-u-cpu` to the gps-raspbian bot.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -337,6 +337,7 @@ SLOW_TIMEOUT = 40 * 60
 # These use a longer timeout for very slow buildbots.
 class SlowNonDebugUnixBuild(NonDebugUnixBuild):
     test_timeout = SLOW_TIMEOUT
+    testFlags = [*NonDebugUnixBuild.testFlags, "-u-cpu"]
 
 
 class SlowUnixInstalledBuild(UnixInstalledBuild):

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -212,6 +212,8 @@ def get_workers(settings):
             tags=['linux', 'unix', 'raspbian', 'debian', 'armv6', 'armv7l',
                   'aarch32', 'arm'],
             parallel_tests=3,
+            # Raspbian Debian bullseye ships with 3.9, bookworm with 3.11.
+            not_branches=['3.7', '3.8'],
         ),
         cpw(
             name="kulikjak-solaris-sparcv9",


### PR DESCRIPTION
skip some knows super slow tests.  not a lot of value in running those here.

also disabled 3.7 and 3.8 runs - not that those really happen very often anymore.