### PR TITLE
Add ASAN and Refleaks MacOS NoGIL builders

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -13,6 +13,7 @@ from custom.factories import (
     UnixRefleakBuild,
     UnixNoGilBuild,
     UnixNoGilRefleakBuild,
+    UnixAsanNoGilBuild,
     AIXBuild,
     AIXBuildWithXLC,
     PGOUnixBuild,
@@ -37,6 +38,7 @@ from custom.factories import (
     Windows64ReleaseBuild,
     MacOSArmWithBrewBuild,
     MacOSArmWithBrewNoGilBuild,
+    MacOSArmWithBrewNoGilRefleakBuild,
     WindowsARM64Build,
     WindowsARM64ReleaseBuild,
     Wasm32EmscriptenNodePThreadsBuild,
@@ -222,6 +224,9 @@ UNSTABLE_BUILDERS_TIER_1 = [
 
     # Windows x86-64 MSVC
     ("AMD64 Windows Server 2022 NoGIL", "itamaro-win64-srv-22-aws", Windows64NoGilBuild),
+
+    # macOS x86-64 clang
+    ("x86-64 MacOS Intel ASNA NoGIL", "itamaro-macos-intel-aws", UnixAsanNoGilBuild),
 ]
 
 
@@ -258,6 +263,9 @@ UNSTABLE_BUILDERS_TIER_2 = [
     ("aarch64 CentOS9 Refleaks", "cstratak-CentOS9-aarch64", UnixRefleakBuild),
     ("aarch64 CentOS9 LTO", "cstratak-CentOS9-aarch64", LTONonDebugUnixBuild),
     ("aarch64 CentOS9 LTO + PGO", "cstratak-CentOS9-aarch64", LTOPGONonDebugBuild),
+
+    # macOS aarch64 clang
+    ("ARM64 MacOS M1 NoGIL Refleaks", "itamaro-macos-arm64-aws", MacOSArmWithBrewNoGilRefleakBuild),
 ]
 
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -250,6 +250,12 @@ class UnixAsanDebugBuild(UnixAsanBuild):
     configureFlags = UnixAsanBuild.configureFlags + ["--with-pydebug"]
 
 
+class UnixAsanNoGilBuild(UnixAsanBuild):
+    buildersuffix = ".asan.nogil"
+    configureFlags = UnixAsanBuild.configureFlags + ["--disable-gil"]
+    factory_tags = UnixAsanBuild.factory_tags + ["nogil"]
+
+
 class UnixBuildWithoutDocStrings(UnixBuild):
     configureFlags = ["--with-pydebug", "--without-doc-strings"]
 
@@ -498,6 +504,16 @@ class MacOSArmWithBrewNoGilBuild(UnixNoGilBuild):
     buildersuffix = ".macos-with-brew.nogil"
     configureFlags = [
         *UnixNoGilBuild.configureFlags,
+        "--with-openssl=/opt/homebrew/opt/openssl@3",
+        "CPPFLAGS=-I/opt/homebrew/include",
+        "LDFLAGS=-L/opt/homebrew/lib",
+    ]
+
+
+class MacOSArmWithBrewNoGilRefleakBuild(UnixNoGilRefleakBuild):
+    buildersuffix = ".macos-with-brew.refleak.nogil"
+    configureFlags = [
+        *UnixNoGilRefleakBuild.configureFlags,
         "--with-openssl=/opt/homebrew/opt/openssl@3",
         "CPPFLAGS=-I/opt/homebrew/include",
         "LDFLAGS=-L/opt/homebrew/lib",


### PR DESCRIPTION
Increase NoGIL MacOS coverage with additional (unstable, for now) builders covering ASAN and Refleaks on MacOS