### PR TITLE
Remove the `bcannon-wasm` worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -174,10 +174,7 @@ STABLE_BUILDERS_TIER_3 = [
     ("ARM64 Windows Non-Debug", "linaro-win-arm64", WindowsARM64ReleaseBuild),
 
     # WebAssembly
-    ("wasm32-emscripten node (pthreads)", "bcannon-wasm", Wasm32EmscriptenNodePThreadsBuild),
-    ("wasm32-emscripten node (dynamic linking)", "bcannon-wasm", Wasm32EmscriptenNodeDLBuild),
-    ("wasm32-emscripten browser (dynamic linking, no tests)", "bcannon-wasm", Wasm32EmscriptenBrowserBuild),
-    ("wasm32-wasi", "bcannon-wasm", Wasm32WASIBuild),
+    ("wasm32-wasi", "bcannon-wasi", Wasm32WASIBuild),
 ]
 
 
@@ -280,7 +277,6 @@ UNSTABLE_BUILDERS_TIER_3 = [
     ("AMD64 FreeBSD15", "opsec-fbsd15", UnixBuild),
 
     # WebAssembly
-    ("wasm32 WASI", "bcannon-wasi", Wasm32WASIBuild),
     ("wasm32 WASI 8Core", "kushaldas-wasi", Wasm32WASIBuild),
 ]
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -276,13 +276,6 @@ def get_workers(settings):
             parallel_builders=2,
         ),
         cpw(
-            name="bcannon-wasm",
-            tags=['wasm', 'emscripten', 'wasi'],
-            not_branches=['3.9', '3.10'],
-            parallel_tests=2,
-            parallel_builders=2,
-        ),
-        cpw(
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
             not_branches=['3.9', '3.10', '3.11'],


### PR DESCRIPTION
Also move the `bcannon-wasi` worker to stable while renaming its WASI builder to match what `bcannon-wasm` used.