### PR TITLE
Enable the GIL for new MacOS Refleak and ASAN builders

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -38,7 +38,7 @@ from custom.factories import (
     Windows64ReleaseBuild,
     MacOSArmWithBrewBuild,
     MacOSArmWithBrewNoGilBuild,
-    MacOSArmWithBrewNoGilRefleakBuild,
+    MacOSArmWithBrewRefleakBuild,
     WindowsARM64Build,
     WindowsARM64ReleaseBuild,
     Wasm32EmscriptenNodePThreadsBuild,
@@ -223,7 +223,7 @@ UNSTABLE_BUILDERS_TIER_1 = [
     ("AMD64 Windows Server 2022 NoGIL", "itamaro-win64-srv-22-aws", Windows64NoGilBuild),
 
     # macOS x86-64 clang
-    ("x86-64 MacOS Intel ASNA NoGIL", "itamaro-macos-intel-aws", UnixAsanNoGilBuild),
+    ("x86-64 MacOS Intel ASAN (No) NoGIL", "itamaro-macos-intel-aws", UnixAsanBuild),
 ]
 
 
@@ -262,7 +262,7 @@ UNSTABLE_BUILDERS_TIER_2 = [
     ("aarch64 CentOS9 LTO + PGO", "cstratak-CentOS9-aarch64", LTOPGONonDebugBuild),
 
     # macOS aarch64 clang
-    ("ARM64 MacOS M1 NoGIL Refleaks", "itamaro-macos-arm64-aws", MacOSArmWithBrewNoGilRefleakBuild),
+    ("ARM64 MacOS M1 (No) NoGIL Refleaks", "itamaro-macos-arm64-aws", MacOSArmWithBrewRefleakBuild),
 ]
 
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -510,6 +510,16 @@ class MacOSArmWithBrewNoGilBuild(UnixNoGilBuild):
     ]
 
 
+class MacOSArmWithBrewRefleakBuild(UnixRefleakBuild):
+    buildersuffix = ".macos-with-brew.refleak"
+    configureFlags = [
+        *UnixRefleakBuild.configureFlags,
+        "--with-openssl=/opt/homebrew/opt/openssl@3",
+        "CPPFLAGS=-I/opt/homebrew/include",
+        "LDFLAGS=-L/opt/homebrew/lib",
+    ]
+
+
 class MacOSArmWithBrewNoGilRefleakBuild(UnixNoGilRefleakBuild):
     buildersuffix = ".macos-with-brew.refleak.nogil"
     configureFlags = [


### PR DESCRIPTION
these new builders have been failing
since we didn't have ASAN and Refleak MacOS builders before, let's switch them over to regular (with GIL) build temporarily to debug and isolate the issues