### PR TITLE
Add `--disable-gil` test flag to Windows NoGIL builder

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -626,7 +626,8 @@ class Windows64ReleaseBuild(Windows64Build):
 
 class Windows64NoGilBuild(Windows64Build):
     buildersuffix = '.x64.nogil'
-    buildFlags = ["-p", "x64", "--disable-gil"]
+    buildFlags = Windows64Build.buildFlags + ["--disable-gil"]
+    testFlags = Windows64Build.testFlags + ["--disable-gil"]
     factory_tags = ["win64", "nogil"]
 
 


### PR DESCRIPTION
since https://github.com/python/cpython/pull/113129 (part of https://github.com/python/cpython/issues/112984), we need to pass `--disable-gil` to `rt.bat` too