### PR TITLE
Disable bigmem tests on 3.12, bump resources to 32GB+ and extralargefile

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -625,7 +625,7 @@ class Windows64Build(BaseWindowsBuild):
 class Windows64BigmemBuild(BaseWindowsBuild):
     buildersuffix = ".bigmem"
     buildFlags = ["-p", "x64"]
-    testFlags = ["-p", "x64", "-M24g", "-uall"]
+    testFlags = ["-p", "x64", "-M33g", "-uall,extralargefile"]
     test_timeout = TEST_TIMEOUT * 4
     cleanFlags = ["-p", "x64"]
     factory_tags = ["win64", "bigmem"]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -278,7 +278,7 @@ def get_workers(settings):
         cpw(
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
-            not_branches=['3.9', '3.10', '3.11'],
+            not_branches=['3.9', '3.10', '3.11', '3.12'],
             parallel_tests=4,
         ),
         cpw(


### PR DESCRIPTION
I don't think we need bigmem tests for a bugfix branch after 3.12.1 and 3.12.2 were released. Unlikely we'll cause a non-main regression that's bigmem only.

Instead, we can use those resources to run larger tests. Previously I configured it to 24 GB per test, because up to 4 tests run in parallel; the entire box is 128 GB RAM. It turns out this setting was skipping tests that want "at least 24GB", like:
```
test_concat_small (test.test_bigmem.TupleTest.test_concat_small) ... skipped 'not enough memory: 24.0G minimum needed'
test_repeat_small (test.test_bigmem.TupleTest.test_repeat_small) ... skipped 'not enough memory: 24.0G minimum needed'
```

Almost all tests will be running with `-M33G` set. There are still a few test cases that want 36 GB+, 48 GB+, and even 53.3 GB in case of `test_dict`. I can't give it that much, unfortunately.

Hmmm, maybe I'll set up a separate nightly build with no parallelism to cover those cases, too. But that's a separate problem.