### PR TITLE
Increase test_timeout on RHEL8-ppc64le for older branches

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -70,6 +70,10 @@ class UnixBuild(BaseBuild):
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
         out_of_tree_dir = "build_oot"
 
+        if branch in kwargs.get("slow_branches", ()):
+            # Increase the timeout on specific branches
+            self.test_timeout *= 2
+
         if self.build_out_of_tree:
             self.addStep(
                 ShellCommand(

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -70,9 +70,8 @@ class UnixBuild(BaseBuild):
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
         out_of_tree_dir = "build_oot"
 
-        if branch in kwargs.get("slow_branches", ()):
-            # Increase the timeout on specific branches
-            self.test_timeout *= 2
+        # Adjust the timeout for this worker
+        self.test_timeout *= kwargs.get("timeout_factor", 1)
 
         if self.build_out_of_tree:
             self.addStep(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -163,8 +163,8 @@ extra_factory_args = {
         "test_with_PTY": True,
     },
     "cstratak-RHEL8-ppc64le": {
-        # Increase the timeout on specific branches
-        "slow_branches": ['3.8', '3.9', '3.10'],
+        # Increase the timeout on this slow worker
+        "timeout_factor": 2,
     },
 
 }

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -162,6 +162,11 @@ extra_factory_args = {
         # test curses as well
         "test_with_PTY": True,
     },
+    "cstratak-RHEL8-ppc64le": {
+        # Increase the timeout on specific branches
+        "slow_branches": ['3.8', '3.9', '3.10'],
+    },
+
 }
 
 # The following with the worker owners' agreement


### PR DESCRIPTION
This particular worker is slow: a successful test_gdb run usually will take about 17 minutes, but often it fails on the 20-minute timeout.

On 3.11+, the tests are split up into three 7-min suites so this isn't a problem, but for older branches it's probably best to solve it in the buildbot config.

This is my first foray into buildbot configuration; please tell me if you'd do this differently.
