### PR TITLE
Use SlowUnixInstalledBuild for onder-riscv64 worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -22,6 +22,7 @@ from custom.factories import (
     ClangUnixInstalledBuild,
     SharedUnixBuild,
     SlowNonDebugUnixBuild,
+    SlowUnixInstalledBuild,
     NonDebugUnixBuild,
     UnixInstalledBuild,
     LTONonDebugUnixBuild,
@@ -303,7 +304,7 @@ UNSTABLE_BUILDERS_NO_TIER = [
     ("SPARCv9 Oracle Solaris 11.4", "kulikjak-solaris-sparcv9", UnixBuild),
 
     # riscv64 GCC
-    ("riscv64 Ubuntu23", "onder-riscv64", UnixBuild),
+    ("riscv64 Ubuntu23", "onder-riscv64", SlowUnixInstalledBuild),
 ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -279,9 +279,6 @@ UNSTABLE_BUILDERS_TIER_3 = [
     # FreBSD x86-64 clang
     # FreeBSD 15 is CURRENT: development branch (at 2023-10-17)
     ("AMD64 FreeBSD15", "opsec-fbsd15", UnixBuild),
-
-    # riscv64 GCC
-    ("riscv64 Ubuntu23", "onder-riscv64", UnixBuild),
 ]
 
 
@@ -304,6 +301,9 @@ UNSTABLE_BUILDERS_NO_TIER = [
 
     # Solaris sparcv9
     ("SPARCv9 Oracle Solaris 11.4", "kulikjak-solaris-sparcv9", UnixBuild),
+
+    # riscv64 GCC
+    ("riscv64 Ubuntu23", "onder-riscv64", UnixBuild),
 ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -279,6 +279,9 @@ UNSTABLE_BUILDERS_TIER_3 = [
     # FreBSD x86-64 clang
     # FreeBSD 15 is CURRENT: development branch (at 2023-10-17)
     ("AMD64 FreeBSD15", "opsec-fbsd15", UnixBuild),
+
+    # riscv64 GCC
+    ("riscv64 Ubuntu23", "onder-riscv64", UnixBuild),
 ]
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -317,6 +317,7 @@ def get_workers(settings):
         cpw(
             name="onder-riscv64",
             tags=['linux', 'unix', 'ubuntu', 'riscv64'],
+            not_branches=['3.9', '3.10'],
             parallel_tests=4,
         ),
     ]

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -314,4 +314,9 @@ def get_workers(settings):
             parallel_tests=4,
             parallel_builders=2,
         ),
+        cpw(
+            name="onder-riscv64",
+            tags=['linux', 'unix', 'ubuntu', 'riscv64'],
+            parallel_tests=4,
+        ),
     ]


### PR DESCRIPTION
This worker needs a long `test_timeout`.

Example: on [build 1376](https://buildbot.python.org/all/#/builders/1376/builds/55/steps/5/logs/stdio), `test_tools` failed with a timeout (20 min)

```sh
1:18:49 load avg: 1.64 running (1): test_tools (19 min 54 sec)
1:18:57 load avg: 1.59 [2/2/1] test_tools worker non-zero exit code (Exit code 1)
Re-running test_tools in verbose mode
test_freeze_simple_script (test.test_tools.test_freeze.TestFreeze.test_freeze_simple_script) ... Timeout (0:20:00)!
Thread 0x0000003faa134020 (most recent call first):
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/selectors.py", line 415 in select
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/subprocess.py", line 2115 in _communicate
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/subprocess.py", line 1209 in communicate
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/subprocess.py", line 550 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Tools/freeze/test/freeze.py", line 35 in _run_quiet
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Tools/freeze/test/freeze.py", line 170 in freeze
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/test_tools/test_freeze.py", line 35 in test_freeze_simple_script
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/case.py", line 589 in _callTestMethod
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/case.py", line 634 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/case.py", line 690 in __call__
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 122 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 84 in __call__
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 122 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 84 in __call__
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 122 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 84 in __call__
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 122 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/suite.py", line 84 in __call__
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/unittest/runner.py", line 240 in run
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 57 in _run_suite
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 37 in run_unittest
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 132 in test_func
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 88 in regrtest_runner
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 135 in _load_run_test
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 178 in _runtest_env_changed_exc
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 278 in _runtest
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/single.py", line 306 in run_single_test
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/worker.py", line 77 in worker_process
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/worker.py", line 100 in main
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/test/libregrtest/worker.py", line 104 in <module>
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/runpy.py", line 88 in _run_code
  File "/home/dietpi/buildarea/3.12.onder-riscv64/build/Lib/runpy.py", line 198 in _run_module_as_main
1 test failed again:
    test_tools
== Tests result: FAILURE then FAILURE ==
10 slowest tests:
- test_math: 13 min 27 sec
- test_unparse: 7 min 21 sec
- test.test_multiprocessing_spawn.test_processes: 7 min 6 sec
- test_lib2to3: 6 min 33 sec
- test_capi: 6 min 33 sec
- test_tokenize: 5 min 58 sec
- test_tarfile: 5 min 48 sec
- test_regrtest: 5 min 22 sec
- test_hashlib: 4 min 6 sec
- test_unicodedata: 3 min 57 sec
14 tests skipped:
    test.test_asyncio.test_windows_events
    test.test_asyncio.test_windows_utils test_devpoll test_ioctl
    test_kqueue test_launcher test_msilib test_nis test_perf_profiler
    test_startfile test_winconsoleio test_winreg test_winsound
    test_wmi
4 tests skipped (resource denied):
    test_tix test_tkinter test_ttk test_zipfile64
2 re-run tests:
    test_json test_tools
1 test failed:
    test_tools
469 tests OK.
```