### PR TITLE
Correct the path to the build python for iOS.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1070,7 +1070,7 @@ class _IOSSimulatorBuild(UnixBuild):
             f"--with-openssl={support_path}/openssl",
             f"--build={self.arch}-apple-darwin",
             f"--host={self.host}",
-            "--with-build-python=../build/python",
+            "--with-build-python=../build/python.exe",
             "--enable-framework"
         ]
 


### PR DESCRIPTION
The build python for the iOS cross-platform build referred to a bare `python`, rather than `python.exe`.
