### PR TITLE
Correct the path to the iOS compiler shims.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1046,7 +1046,7 @@ class _IOSSimulatorBuild(UnixBuild):
         support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
         self.compile_environ.update({
             "PATH": os.pathsep.join([
-                os.path.join(oot_host_path, "iOS/Resources/bin"),
+                "${PWD}/iOS/Resources/bin",
                 "/usr/bin",
                 "/bin",
                 "/usr/sbin",


### PR DESCRIPTION
The iOS buildbot requires a path modification to put the compiler shims onto the path. The previous value was a relative path that wasn't anchored in the working directory (the iOS out-of-tree build directory). This change *should* modify that path to be absolute.