### PR TITLE
Use a relative path for iOS compiler shims.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1046,7 +1046,10 @@ class _IOSSimulatorBuild(UnixBuild):
         support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
         self.compile_environ.update({
             "PATH": os.pathsep.join([
-                "${PWD}/iOS/Resources/bin",
+                # This is intentionally a relative path. Buildbot doesn't expose
+                # the absolute working directory where the build is running as
+                # something that can be expanded into an environment variable.
+                "../../iOS/Resources/bin",
                 "/usr/bin",
                 "/bin",
                 "/usr/sbin",


### PR DESCRIPTION
`${PWD}` resolves as `~buildbot`; so we need to use a relative path, and rely on the fact that the working directory will be consistent in practice.