### PR TITLE
Ensure a clean copy of configure arguments is used

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -750,7 +750,9 @@ class UnixCrossBuild(UnixBuild):
 
         # Now that we have a "build" architecture Python, we can use that
         # to build a "host" (also known as the target we are cross compiling)
-        configure_cmd = self.host_configure_cmd + ["--prefix", "$(PWD)/target/host"]
+        # Take a copy so that the class-level definition isn't tainted
+        configure_cmd = list(self.host_configure_cmd)
+        configure_cmd += ["--prefix", "$(PWD)/target/host"]
         configure_cmd += self.configureFlags + self.extra_configure_flags
         configure_cmd += [util.Interpolate("--build=%(prop:build_triple)s")]
         configure_cmd += [f"--host={self.host}"]
@@ -1067,7 +1069,8 @@ class _IOSSimulatorBuild(UnixBuild):
 
         # Now that we have a "build" architecture Python, we can use that
         # to build a "host" (also known as the target we are cross compiling)
-        configure_cmd = self.host_configure_cmd
+        # Take a copy so that the class-level definition isn't tainted
+        configure_cmd = list(self.host_configure_cmd)
         configure_cmd += self.configureFlags
         configure_cmd += self.extra_configure_flags
         configure_cmd += [


### PR DESCRIPTION
This is a variation on the change introduced by #473.

`host_configure_args` is defined as a class-level variable; however, there are build steps that assign this class-level instance directly to `configure_cmd`, and then concatenate build-specific commands. As a result, configure command line arguments can be duplicated (sometimes in contradictory ways).

I noticed this on the iOS builds; see L3 defining the `args` in [this build](https://buildbot.python.org/all/#/builders/1380/builds/43/steps/6/logs/stdio) - there are essentially three copies of the same command line arguments (`--with-pydebug` et al is defined 3 times).

However, it also impacts on any build that uses the `UnixCrossBuild` base class. AFAICT, the only example of a builder affected by this that is currently in use is the (now deprecated) WASI32 builders; those end up with artefacts like the `--with-pydebug --without-pydebug` arguments in [this build log](https://buildbot.python.org/all/#/builders/1374/builds/871/steps/8/logs/stdio). This doesn't appear to be causing problems at present, but it is at the very least confusing.

This PR takes a copy of the class-level `host_configure_args` variable before modifying it, which should prevent different instance setups tainting each other. This is a pattern that is also followed by the handling of other args (e.g., `defaultTestOpts` and `testFlags`).