### PR TITLE
Decrease parallel tests on itamaro ubuntu worker

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -285,7 +285,7 @@ def get_workers(settings):
             name="itamaro-ubuntu-aws",
             tags=['linux', 'unix', 'ubuntu', 'amd64', 'x86-64'],
             not_branches=['3.9', '3.10', '3.11', '3.12'],
-            parallel_tests=10,
+            parallel_tests=4,
             parallel_builders=2,
         ),
         cpw(


### PR DESCRIPTION
This worker was having a hard time recently.
I think it might be that now the builders it's running are covering more branches (3.13 + main), so it is more likely now that multiple builders are running concurrently. I want to try reducing parallel tests (4 is more in line with the typical configuration) to see if it improves things (if it doesn't, we can try reducing parallel builders).
