### PR TITLE
Have WASI debug builds skip CPU-intensive tests https://github.com/python/cpython/issues/118916

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -969,6 +969,7 @@ class _Wasm32WasiBuild(UnixBuild):
 class Wasm32WasiDebugBuild(_Wasm32WasiBuild):
     append_suffix = ".debug"
     pydebug = True
+    testFlags = ["-u-cpu"]
 
 
 class _IOSSimulatorBuild(UnixBuild):


### PR DESCRIPTION
added line to
class Wasm32WasiDebugBuild
L972 
to prevent test timeout