### PR TITLE
Remove buildbot workers hosted on my ex-employer's cloud.

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -69,7 +69,6 @@ NO_TIER = None
 STABLE_BUILDERS_TIER_1 = [
     # Linux x86-64 GCC
     ("AMD64 Debian root", "angelico-debian-amd64", UnixBuild),
-    ("AMD64 Debian PGO", "gps-debian-profile-opt", PGOUnixBuild),
     ("AMD64 Ubuntu Shared", "bolen-ubuntu", SharedUnixBuild),
     ("AMD64 Fedora Stable", "cstratak-fedora-stable-x86_64", FedoraStableBuild),
     ("AMD64 Fedora Stable Refleaks", "cstratak-fedora-stable-x86_64", UnixRefleakBuild),
@@ -136,8 +135,6 @@ STABLE_BUILDERS_TIER_2 = [
     ("aarch64 RHEL8 Refleaks", "cstratak-RHEL8-aarch64", UnixRefleakBuild),
     ("aarch64 RHEL8 LTO", "cstratak-RHEL8-aarch64", LTONonDebugUnixBuild),
     ("aarch64 RHEL8 LTO + PGO", "cstratak-RHEL8-aarch64", LTOPGONonDebugBuild),
-
-    ("aarch64 Debian Clang LTO + PGO", "gps-arm64-debian", ClangLTOPGONonDebugBuild),
 
     # macOS aarch64 clang
     ("ARM64 macOS", "pablogsal-macos-m1", MacOSArmWithBrewBuild),
@@ -236,7 +233,6 @@ UNSTABLE_BUILDERS_TIER_2 = [
     # UBSan is a special build
     ("AMD64 Fedora Rawhide Clang", "cstratak-fedora-rawhide-x86_64", ClangUnixBuild),
     ("AMD64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-x86_64", ClangUnixInstalledBuild),
-    ("AMD64 Clang UBSan", "gps-clang-ubsan", ClangUbsanLinuxBuild),
 
     # Linux ppc64le GCC
     # Fedora Rawhide is unstable

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -194,20 +194,6 @@ def get_workers(settings):
             parallel_tests=6,
         ),
         cpw(
-            name="gps-clang-ubsan",
-            tags=['linux', 'unix', 'amd64', 'x86-64'],
-        ),
-        cpw(
-            name="gps-debian-profile-opt",
-            tags=['linux', 'unix', 'debian', 'amd64', 'x86-64'],
-        ),
-        cpw(
-            name="gps-arm64-debian",
-            tags=['linux', 'unix', 'arm64', 'aarch64', 'arm', 'debian'],
-            parallel_tests=7,  # Shortest test time; 4 vCPU host.
-            not_branches=['3.9'],
-        ),
-        cpw(
             name="gps-raspbian",
             tags=['linux', 'unix', 'raspbian', 'debian', 'armv6', 'armv7l',
                   'aarch32', 'arm'],


### PR DESCRIPTION
I no longer have access to these GCE VMs.

Something happened on or after 8-9 days ago on or after 939c201e00943c6dc2d515185168c30606ae522c (probably not that change, but I didn't try to figure out what) with the gps-debian-profile-opt bot that likely lead to runaway busy-looping processes for several builds on both 3.x and 3.13 branches, causing it to take 3 hours instead of 20 minutes to complete a run after that.

Time to shut the bot I cannot administer anymore down, lets just take care of all three of them at once.

@Yhg1s still works there and may have access to these bots via the cloud.google.com console on his corp account if I recall correctly who I added to the config. So if you want these to stay up during the 3.13beta releases, please investigate and confirm your access.

If anyone with access at Google wants to take these over and keep them running (very infrequent baby sitting - update & reboot a few times a year, so little I never bothered automating it), they need to reconfigure them and get their own CPython buildbot password to store in the config; follow the instructions linked to at the end of https://www.python.org/dev/buildbot/ to do that.  I don't want my name associated with these bots any longer if they continue to exist.  It is likely easier for you to setup your own replacements than to adopt mine and reconfigure.