### PR TITLE
Remove the explicit iOS minimum version.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -981,7 +981,7 @@ class _IOSSimulatorBuild(UnixBuild):
      * It invokes `make testios` as a test target
     """
     buildersuffix = ".iOS-simulator"
-    ios_min_version = "12.0"
+    ios_min_version = ""  # use the default from the configure file
     factory_tags = ["iOS"]
     extra_configure_flags = []
     host_configure_cmd = ["../../configure"]


### PR DESCRIPTION
python/cpython#121250 increases the default minimum iOS version to 13.0; however, the buildbot has an explicitly encoded iOS minimum version of 12.0. 

This modifies the builder configuration to fall back to the default unless specifically configured for a particular version.