### PR TITLE
Revert "Replace buildbot-wsgi-dashboards with buildbot-react-wsgi-das…

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 buildbot[bundle,tls]
-buildbot-react-wsgi-dashboards
+buildbot_wsgi_dashboards
 flask
 PyYAML
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ blinker==1.8.2
 buildbot==4.0.0
 buildbot-console-view==4.0.0
 buildbot-grid-view==4.0.0
-buildbot-react-wsgi-dashboards==4.0.0
 buildbot-waterfall-view==4.0.0
 buildbot-worker==4.0.0
+buildbot-wsgi-dashboards==4.0.0
 buildbot-www==4.0.0
 certifi==2024.7.4
 cffi==1.16.0


### PR DESCRIPTION
…hboards (#499)"

This reverts commit 740f62478406d15874ed68e15e30645cffc7ef8c.

Buildbot failed with:

```
    (...)
    File "/srv/buildbot/venv/lib/python3.9/site-packages/buildbot/www/service.py", line 225, in reconfigServiceWithBuildbotConfig
      self.setupSite(new_config)
    File "/srv/buildbot/venv/lib/python3.9/site-packages/buildbot/www/service.py", line 325, in setupSite
      self.configPlugins(root, new_config)
    File "/srv/buildbot/venv/lib/python3.9/site-packages/buildbot/www/service.py", line 302, in configPlugins
      raise RuntimeError(f"could not find plugin {key}; is it installed?")
  builtins.RuntimeError: could not find plugin wsgi_dashboards; is it installed?
```