### PR TITLE
Several lint-level fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ regen-requirements:
 .PHONY: check
 
 check: $(VENV_CHECK)
-	$(BUILDBOT) checkconfig master/master.cfg
+	$(BUILDBOT) checkconfig master
 
 # Management targets
 

--- a/master/custom/schedulers.py
+++ b/master/custom/schedulers.py
@@ -50,7 +50,7 @@ class GitHubPrScheduler(AnyBranchScheduler):
                 kwargs.update(builderNames=builder_names)
                 yield super().addBuildsetForChanges(**kwargs)
             else:
-                log.msg(f"No matching builders after filtering - breaking out")
+                log.msg("No matching builders after filtering - breaking out")
             return
 
         log.msg("Scheduling regular non-filtered buildset")

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -17,7 +17,7 @@ import sys
 from datetime import timedelta
 from functools import partial
 
-from buildbot.schedulers.basic import SingleBranchScheduler, AnyBranchScheduler
+from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.schedulers.forcesched import ForceScheduler
 from buildbot.schedulers.timed import Nightly
 from buildbot.plugins import reporters, util
@@ -39,27 +39,29 @@ for k in list(sys.modules):
     if k.split(".")[0] in ["custom"]:
         sys.modules.pop(k)
 
-from custom import MAIN_BRANCH_NAME
+from custom import MAIN_BRANCH_NAME  # noqa: E402
 from custom.auth import set_up_authorization  # noqa: E402
 from custom.email_formatter import MESSAGE_FORMATTER  # noqa: E402
 from custom.pr_reporter import GitHubPullRequestReporter  # noqa: E402
 from custom.discord_reporter import DiscordReporter  # noqa: E402
-from custom.pr_testing import (
+from custom.pr_testing import (  # noqa: E402
     CustomGitHubEventHandler,
     should_pr_be_tested,
-)  # noqa: E402
+)
 from custom.settings import Settings  # noqa: E402
 from custom.steps import Git, GitHub  # noqa: E402
 from custom.workers import get_workers  # noqa: E402
 from custom.schedulers import GitHubPrScheduler # noqa: E402
 from custom.release_dashboard import get_release_status_app    # noqa: E402
-from custom.builders import (
+from custom.builders import (  # noqa: E402
     get_builders,
     STABLE,
     DAILYBUILDERS,
     ONLY_MAIN_BRANCH,
-    TIER_1, TIER_2,
-)  # noqa: E402
+    TIER_1,
+    TIER_2,
+)
+
 
 def set_up_sentry():
     try:
@@ -82,6 +84,7 @@ def set_up_sentry():
         sentry_sdk.capture_exception((f.type, f.value, f.getTracebackObject()))
 
     log.addObserver(logToSentry)
+
 
 settings_path = os.path.join('/etc', 'buildbot', 'settings.yaml')
 settings_path = os.environ.get('PYBUILDBOT_SETTINGS_PATH', settings_path)
@@ -238,7 +241,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             branch=branchname,
             **extra_factory_args.get(worker_name, {}),
         )
-        tags = [branchname, stability,] + getattr(f, "tags", [])
+        tags = [branchname, stability, *getattr(f, "tags", [])]
         if tier:
             tags.append(tier)
 
@@ -323,7 +326,7 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
         **extra_factory_args.get(worker_name, {}),
     )
 
-    tags = ["PullRequest", stability,] + getattr(f, "tags", [])
+    tags = ["PullRequest", stability, *getattr(f, "tags", [])]
     if tier:
         tags.append(tier)
     c["builders"].append(
@@ -486,7 +489,6 @@ c["services"].append(
         verbose=bool(settings.verbosity),
     )
 )
-
 
 
 # if you set 'manhole', you can telnet into the buildmaster and get an

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -262,9 +262,6 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
                 # Only Tier-1 and Tier-2 builders can block a release
                 if tier in (TIER_1, TIER_2):
                     release_status_builders.append(buildername)
-        tags = [branchname, stability,] + getattr(f, "tags", [])
-        if tier:
-            tags.append(tier)
         c["builders"].append(
             util.BuilderConfig(
                 name=buildername,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -17,15 +17,7 @@ import sys
 from datetime import timedelta
 from functools import partial
 
-from buildbot.schedulers.basic import SingleBranchScheduler
-from buildbot.schedulers.forcesched import ForceScheduler
-from buildbot.schedulers.timed import Nightly
-from buildbot.plugins import reporters, util
-from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
-from buildbot.reporters.generators.buildrequest import BuildRequestGenerator
-from buildbot.reporters.generators.buildset import BuildSetStatusGenerator
-from buildbot.reporters.generators.worker import WorkerMissingGenerator
-from buildbot.reporters.message import MessageFormatterRenderable
+from buildbot.plugins import reporters, schedulers, util
 from buildbot import locks
 from twisted.python import log
 
@@ -277,7 +269,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             )
         )
     c["schedulers"].append(
-        SingleBranchScheduler(
+        schedulers.SingleBranchScheduler(
             name=branchname,
             change_filter=util.ChangeFilter(branch=git_branch),
             treeStableTimer=30,  # seconds
@@ -287,7 +279,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
     )
     if dailybuildernames:
         c["schedulers"].append(
-            Nightly(
+            schedulers.Nightly(
                 name=branchname + "-daily",
                 hour=int(branch_num / (len(git_branches) - 1) * 23),
                 minute=0,
@@ -355,7 +347,7 @@ c["schedulers"].append(
 # Set up aditional schedulers
 
 c["schedulers"].append(
-    ForceScheduler(
+    schedulers.ForceScheduler(
         name="force",
         builderNames=[builder.name for builder in c["builders"]],
         reason=util.FixedParameter(name="reason", label="reason", default=""),
@@ -415,12 +407,12 @@ if bool(settings.send_mail):
     c["services"].append(
         reporters.MailNotifier(
             generators=[
-                BuildSetStatusGenerator(
+                reporters.BuildSetStatusGenerator(
                     mode='problem',
                     builders=mail_status_builders,
                     message_formatter=MESSAGE_FORMATTER,
                 ),
-                WorkerMissingGenerator(workers='all'),
+                reporters.WorkerMissingGenerator(workers='all'),
             ],
             fromaddr=str(settings.from_email),
             relayhost=str(settings.email_relay_host),
@@ -455,23 +447,27 @@ c["services"].append(
     reporters.GitHubStatusPush(
         str(settings.github_status_token),
         generators=[
-            BuildStartEndStatusGenerator(builders=github_status_builders + all_pull_request_builders),
+            reporters.BuildStartEndStatusGenerator(
+                builders=github_status_builders + all_pull_request_builders,
+            ),
         ],
         verbose=bool(settings.verbosity),
     )
 )
 
-start_formatter = MessageFormatterRenderable('Build started.')
-end_formatter = MessageFormatterRenderable('Build done.')
-pending_formatter = MessageFormatterRenderable('Build pending.')
+start_formatter = reporters.MessageFormatterRenderable('Build started.')
+end_formatter = reporters.MessageFormatterRenderable('Build done.')
+pending_formatter = reporters.MessageFormatterRenderable('Build pending.')
 c["services"].append(
     GitHubPullRequestReporter(
         str(settings.github_status_token),
         generators=[
-            BuildRequestGenerator(formatter=pending_formatter),
-            BuildStartEndStatusGenerator(builders=github_status_builders,
-                                         start_formatter=start_formatter,
-                                         end_formatter=end_formatter),
+            reporters.BuildRequestGenerator(formatter=pending_formatter),
+            reporters.BuildStartEndStatusGenerator(
+                builders=github_status_builders,
+                start_formatter=start_formatter,
+                end_formatter=end_formatter,
+            ),
         ],
         verbose=bool(settings.verbosity),
     )
@@ -481,10 +477,12 @@ c["services"].append(
     DiscordReporter(
         str(settings.discord_webhook),
         generators=[
-            BuildRequestGenerator(formatter=pending_formatter),
-            BuildStartEndStatusGenerator(builders=github_status_builders,
-                                         start_formatter=start_formatter,
-                                         end_formatter=end_formatter),
+            reporters.BuildRequestGenerator(formatter=pending_formatter),
+            reporters.BuildStartEndStatusGenerator(
+                builders=github_status_builders,
+                start_formatter=start_formatter,
+                end_formatter=end_formatter,
+            ),
         ],
         verbose=bool(settings.verbosity),
     )


### PR DESCRIPTION
- **Remove superfluous recomputing of builder tags**
- **Apply lint roller**
- **Adjust 'make check' to also check buildbot.tac**
- **Fix buildbot imports to use the now recommended pattern**
