### PR TITLE
Add Android configuration

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -46,6 +46,7 @@ from custom.factories import (
     Wasm32WasiCrossBuild,
     Wasm32WasiDebugBuild,
     IOSARM64SimulatorBuild,
+    AndroidBuild,
 )
 
 # A builder can be marked as stable when at least the 10 latest builds are
@@ -182,6 +183,10 @@ STABLE_BUILDERS_TIER_3 = [
 
     # iOS
     ("iOS ARM64 Simulator", "rkm-arm64-ios-simulator", IOSARM64SimulatorBuild),
+
+    # Android
+    ("aarch64 Android", "mhsmith-android-aarch64", AndroidBuild),
+    ("AMD64 Android", "mhsmith-android-x86_64", AndroidBuild),
 ]
 
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -968,6 +968,10 @@ class Wasm32WasiDebugBuild(_Wasm32WasiBuild):
     testFlags = ["-u-cpu"]
 
 
+##############################################################################
+################################  IOS BUILDS  ################################
+##############################################################################
+
 class _IOSSimulatorBuild(UnixBuild):
     """iOS Simulator build.
 
@@ -1146,3 +1150,71 @@ class _IOSSimulatorBuild(UnixBuild):
 class IOSARM64SimulatorBuild(_IOSSimulatorBuild):
     """An ARM64 iOS simulator build."""
     arch = "arm64"
+
+
+##############################################################################
+##############################  ANDROID BUILDS  ##############################
+##############################################################################
+
+class AndroidBuild(BaseBuild):
+    """Build Python for Android on a Linux or Mac machine, and test it using a
+    Gradle-managed emulator. Worker setup instructions:
+
+    * Install all the usual tools and libraries needed to build Python for the
+      worker's own operating system.
+
+    * Follow the instructions in the Prerequisites section of
+      cpython/Android/README.md.
+
+    * On Linux:
+      * Make sure the worker has access to the KVM virtualization interface.
+      * Start an X server such as Xvfb, and set the DISPLAY environment variable
+        to point at it.
+    """
+
+    def setup(self, **kwargs):
+        android_py = "Android/android.py"
+        self.addSteps([
+            SetPropertyFromCommand(
+                name="Get build triple",
+                command=["./config.guess"],
+                property="build_triple",
+                haltOnFailure=True,
+            ),
+            Configure(
+                name="Configure build Python",
+                command=[android_py, "configure-build"],
+            ),
+            Compile(
+                name="Compile build Python",
+                command=[android_py, "make-build"],
+            ),
+            Configure(
+                name="Configure host Python",
+                command=[android_py, "configure-host", self.host_triple],
+            ),
+            Compile(
+                name="Compile host Python",
+                command=[android_py, "make-host", self.host_triple],
+            ),
+            Compile(
+                name="Build testbed",
+                command=[android_py, "build-testbed"],
+            ),
+            Test(
+                command=[
+                    android_py, "test", "--managed", "maxVersion", "--",
+                    "-W", "-uall",
+                ],
+                timeout=step_timeout(self.test_timeout),
+            ),
+            ShellCommand(
+                name="Clean",
+                command=[android_py, "clean"],
+            ),
+        ])
+
+    @util.renderer
+    def host_triple(props):
+        build_triple = props.getProperty("build_triple")
+        return build_triple.split("-")[0] + "-linux-android"

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -312,4 +312,16 @@ def get_workers(settings):
             not_branches=['3.9', '3.10', '3.11', '3.12'],
             parallel_builders=4,
         ),
+        cpw(
+            name="mhsmith-android-aarch64",
+            tags=['android'],
+            not_branches=['3.9', '3.10', '3.11', '3.12'],
+            parallel_builders=1,  # All builds use the same emulator and app ID.
+        ),
+        cpw(
+            name="mhsmith-android-x86_64",
+            tags=['android'],
+            not_branches=['3.9', '3.10', '3.11', '3.12'],
+            parallel_builders=1,  # All builds use the same emulator and app ID.
+        ),
     ]


### PR DESCRIPTION
* Issue: https://github.com/python/buildmaster-config/issues/511

This PR adds configuration for two Android builders and two workers, one each for ARM64 and x86-64.

Before merging this PR, please also update the settings as follows:
* Rename the worker `mhsmith-android-arm64` to `mhsmith-android-aarch64`, for consistency with the existing workers.
* Add a new worker called `mhsmith-android-x86_64`, with the same password.
