### PR TITLE
Limit non-debug WASI builds to 3.11 and 3.12

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -239,9 +239,13 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
 
         # Only 3.11+ for WebAssembly builds
         if "wasm" in tags:
+            # WASM wasn't a supported platform until 3.11.
             if branchname in {"3.9", "3.10"}:
                 continue
-            # Pydebug support is 3.13+
+            # Tier 3 support is 3.11 & 3.12.
+            elif "nondebug" in tags and branchname not in {"3.11", "3.12"}:
+                continue
+            # Tier 2 support is 3.13+.
             elif "nondebug" not in tags and branchname in {"3.11", "3.12"}:
                 continue
 


### PR DESCRIPTION
Those versions are when WASI was tier 3 and the files in `Tools/wasm` used for the build are removed in 3.14.