### PR TITLE
Mark the passing UBSAN build as stable, the failing one as unstable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -187,10 +187,12 @@ STABLE_BUILDERS_NO_TIER = [
     # Special builds: FIPS, ASAN, UBSAN, TraceRefs, Perf, etc.
     ("AMD64 RHEL8 FIPS Only Blake2 Builtin Hash", "cstratak-RHEL8-fips-x86_64", RHEL8NoBuiltinHashesUnixBuildExceptBlake2),
     ("AMD64 Arch Linux Asan", "pablogsal-arch-x86_64", UnixAsanBuild),
-    ("AMD64 Arch Linux Usan", "pablogsal-arch-x86_64", ClangUbsanLinuxBuild),
     ("AMD64 Arch Linux Asan Debug", "pablogsal-arch-x86_64", UnixAsanDebugBuild),
     ("AMD64 Arch Linux TraceRefs", "pablogsal-arch-x86_64", UnixTraceRefsBuild),
     ("AMD64 Arch Linux Perf", "pablogsal-arch-x86_64", UnixPerfBuild),
+    # UBSAN with -fno-sanitize=function, without which we currently fail (as
+    #  tracked in gh-111178). The full "AMD64 Arch Linux Usan" is unstable, below
+    ("AMD64 Arch Linux Usan Function", "pablogsal-arch-x86_64", ClangUbsanFunctionLinuxBuild),
 
     # Linux s390x Clang
     ("s390x Fedora Clang", "edelsohn-fedora-z", ClangUnixBuild),
@@ -314,8 +316,8 @@ UNSTABLE_BUILDERS_NO_TIER = [
     # riscv64 GCC
     ("riscv64 Ubuntu23", "onder-riscv64", SlowUnixInstalledBuild),
 
-    # Arch Usan Function
-    ("AMD64 Arch Linux Usan Function", "pablogsal-arch-x86_64", ClangUbsanFunctionLinuxBuild),
+    # Arch Usan (see stable "AMD64 Arch Linux Usan Function" above)
+    ("AMD64 Arch Linux Usan", "pablogsal-arch-x86_64", ClangUbsanLinuxBuild),
 ]
 
 


### PR DESCRIPTION
PR #519 added the "AMD64 Arch Linux Usan Function" UBSAN builder with -fno-sanitize=function, but made it unstable and left the existing USAN builder with all checks as stable.

We currently need this skip in order to pass, so the Function one should be marked stable (until gh-111178 is fixed & we can merge the two builders again).