### PR TITLE
Add RHEL8 and RHEL9 s390x workers and builders

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -138,6 +138,17 @@ STABLE_BUILDERS_TIER_2 = [
 
 # -- Stable Tier-3 builder ----------------------------------------------
 STABLE_BUILDERS_TIER_3 = [
+
+    # Linux s390x GCC
+    ("s390x RHEL9", "cstratak-rhel9-s390x", UnixBuild),
+    ("s390x RHEL9 Refleaks", "cstratak-rhel9-s390x", UnixRefleakBuild),
+    ("s390x RHEL9 LTO", "cstratak-rhel9-s390x", LTONonDebugUnixBuild),
+    ("s390x RHEL9 LTO + PGO", "cstratak-rhel9-s390x", LTOPGONonDebugBuild),
+    ("s390x RHEL8", "cstratak-rhel8-s390x", UnixBuild),
+    ("s390x RHEL8 Refleaks", "cstratak-rhel8-s390x", UnixRefleakBuild),
+    ("s390x RHEL8 LTO", "cstratak-rhel8-s390x", LTONonDebugUnixBuild),
+    ("s390x RHEL8 LTO + PGO", "cstratak-rhel8-s390x", LTOPGONonDebugBuild),
+
     # Linux ppc64le Clang
     ("PPC64LE Fedora Stable Clang", "cstratak-fedora-stable-ppc64le", ClangUnixBuild),
     ("PPC64LE Fedora Stable Clang Installed", "cstratak-fedora-stable-ppc64le", ClangUnixInstalledBuild),

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -145,6 +145,16 @@ def get_workers(settings):
             parallel_tests=40,
         ),
         cpw(
+            name="cstratak-rhel8-s390x",
+            tags=['linux', 'unix', 'rhel', 's390x'],
+            parallel_tests=10,
+        ),
+        cpw(
+            name="cstratak-rhel9-s390x",
+            tags=['linux', 'unix', 'rhel', 's390x'],
+            parallel_tests=10,
+        ),
+        cpw(
             name="edelsohn-aix-ppc64",
             tags=['aix', 'unix', 'ppc64'],
             parallel_tests=10,


### PR DESCRIPTION
Replacing two of the s390x workers that were retired recently.