### PR TITLE
Stop testing 3.13 on bigmem after final release

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -230,7 +230,7 @@ def get_workers(settings):
         cpw(
             name="ambv-bb-win11",
             tags=['windows', 'win11', 'amd64', 'x86-64', 'bigmem'],
-            not_branches=['3.9', '3.10', '3.11', '3.12'],
+            not_branches=['3.9', '3.10', '3.11', '3.12', '3.13'],
             parallel_tests=4,
         ),
         cpw(


### PR DESCRIPTION
Just like after the release of 3.12, we don't want to test 3.13 anymore on bigmem after its final release since those tests take up 80+ minutes to finish. We're freeing up resources for 3.14.