### PR TITLE
Improve the Release status dashboard

### DIFF
--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -659,7 +659,6 @@ class BuilderDisconnected(Problem):
     builder: Builder
 
     def get_severity_and_description(self):
-       try:
         if not self.builder.is_stable:
             severity = Severity.disconnected_unstable_builder
             description = "Disconnected unstable builder"
@@ -678,8 +677,6 @@ class BuilderDisconnected(Problem):
                     severity = Severity.TRIVIAL
             break
         return severity, description
-       except:
-           raise SystemError
 
 
 class NoProblem(Problem):

--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -367,8 +367,11 @@ class Build(DashboardObject):
 
     @cached_property
     def started_at(self):
-        if self["started_at"]:
-            return datetime.datetime.fromtimestamp(self["started_at"],
+        started_at = self["started_at"]
+        if isinstance(started_at, datetime.datetime):
+            return started_at
+        if started_at:
+            return datetime.datetime.fromtimestamp(started_at,
                                                    tz=datetime.timezone.utc)
 
     @cached_property

--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -1,13 +1,27 @@
 import datetime
 import os
 import time
+from functools import cached_property, total_ordering
+import enum
+from dataclasses import dataclass
+import itertools
+import urllib.request
+import urllib.error
+import json
+from pathlib import Path
+from xml.etree import ElementTree
 
 from flask import Flask
 from flask import render_template, request
+import jinja2
+import humanize
 
 from buildbot.data.resultspec import Filter
+import buildbot.process.results
 
-FAILED_BUILD_STATUS = 2
+N_BUILDS = 200
+MAX_CHANGES = 50
+
 
 # Cache result for 6 minutes. Generating the page is slow and a Python build
 # takes at least 5 minutes, a common build takes 10 to 30 minutes.  There is a
@@ -15,108 +29,702 @@ FAILED_BUILD_STATUS = 2
 # get a cache hit.
 CACHE_DURATION = 6 * 60
 
+BRANCHES_URL = "https://raw.githubusercontent.com/python/devguide/main/include/release-cycle.json"
 
-def get_release_status_app(buildernames):
-    release_status_app = Flask("test", root_path=os.path.dirname(__file__))
-    buildernames = set(buildernames)
-    cache = None
 
-    def get_release_status():
-        builders = release_status_app.buildbot_api.dataGet("/builders")
+def _gimme_error(func):
+    """Decorator to turn AttributeError into a different Exception
 
-        failed_builds_by_branch_and_tier = {}
-        disconnected_workers = {}
+    jinja2 tends to swallow AttributeError or report it in some place it
+    didn't happen. When that's a problem, use this decorator to get
+    a usable traceback.
+    """
+    def decorated(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except AttributeError as e:
+            raise Exception(f'your error: {e!r}')
+    return decorated
 
-        for builder in builders:
-            if builder["name"] not in buildernames:
+
+class DashboardObject:
+    """Base wrapper for a dashboard object.
+
+    Acts as a dict with the info we get (usually) from JSON API.
+
+    All computed information should be cached using @cached_property.
+    For a fresh view, discard all these objects and build them again.
+    (Computing info on demand means the "for & if" logic in the template
+    doesn't need to be duplicated in Python code.)
+
+    Objects are arranged in a tree: every one (except the root) has a parent.
+    (Cross-tree references must go through the root.)
+
+    N.B.: In Jinja, mapping keys and attributes are interchangeable.
+    Shadow the `info` dict wisely.
+    """
+    def __init__(self, parent, info):
+        self._parent = parent
+        self._root = parent._root
+        self._info = info
+
+    def __getitem__(self, key):
+        return self._info[key]
+
+    def dataGet(self, *args, **kwargs):
+        """Call Buildbot API"""
+        # Buildbot sets `buildbot_api` as an attribute on the WSGI app,
+        # a bit later than we'd like. Get to it dynamically.
+        return self._root._app.flask_app.buildbot_api.dataGet(*args, **kwargs)
+
+    def __repr__(self):
+        return f'<{type(self).__name__} at {id(self)}: {self._info}>'
+
+
+class DashboardState(DashboardObject):
+    """The root of our abstraction, a bit special.
+    """
+    def __init__(self, app):
+        self._root = self
+        self._app = app
+        super().__init__(self, {})
+        self._tiers = {}
+
+    @cached_property
+    def builders(self):
+        active_builderids = set()
+        for worker in self.workers:
+            for cnf in worker["configured_on"]:
+                active_builderids.add(cnf["builderid"])
+        return [
+            Builder(self, info)
+            for info in self.dataGet("/builders")
+            if info["builderid"] in active_builderids
+        ]
+
+    @cached_property
+    def workers(self):
+        return [Worker(self, info) for info in self.dataGet("/workers")]
+
+    @cached_property
+    def branches(self):
+        branches = []
+        for version, info in self._app.branch_info.items():
+            if info['status'] == 'end-of-life':
                 continue
+            if info['branch'] == 'main':
+                tag = '3.x'
+            else:
+                tag = version
+            branches.append(Branch(self, {
+                **info, 'version': version, 'tag': tag
+            }))
+        branches.append(self._no_branch)
+        return branches
 
-            if "stable" not in builder["tags"]:
-                continue
+    @cached_property
+    def _no_branch(self):
+        return Branch(self, {'tag': 'no-branch'})
 
-            for worker in release_status_app.buildbot_api.dataGet(
-                ("builders", builder["builderid"], "workers"),
+    @cached_property
+    def tiers(self):
+        tiers = [Tier(self, {'tag': f'tier-{n}'}) for n in range(1, 4)]
+        tiers.append(self._no_tier)
+        return tiers
+
+    @cached_property
+    def _no_tier(self):
+        # Hack: 'tierless' sorts after 'tier-#' alphabetically,
+        # so we don't need to use numeric priority to sort failures by tier
+        return Tier(self, {'tag': 'tierless'})
+
+    @cached_property
+    def now(self):
+        return datetime.datetime.now(tz=datetime.timezone.utc)
+
+
+def cached_sorted_property(func=None, /, **sort_kwargs):
+    """Like cached_property, but calls sorted() on the value
+
+    This is sometimes used just to turn a generator into a list, as the
+    Jinja template generally likes to know if sequences are empty.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            return sorted(func(*args, **kwargs), **sort_kwargs)
+        return cached_property(wrapper)
+    if func:
+        return decorator(func)
+    return decorator
+
+
+@total_ordering
+class Builder(DashboardObject):
+    @cached_property
+    def builds(self):
+        endpoint = ("builders", self["builderid"], "builds")
+        infos = self.dataGet(
+            endpoint,
+            limit=N_BUILDS,
+            order=["-complete_at"],
+            filters=[Filter("complete", "eq", ["True"])],
+        )
+        builds = []
+        for info in infos:
+            builds.append(Build(self, info))
+        return [Build(self, info) for info in infos]
+
+    @cached_property
+    def tags(self):
+        return frozenset(self["tags"])
+
+    @cached_property
+    def branch(self):
+        for branch in self._parent.branches:
+            if branch.tag in self.tags:
+                return branch
+        return self._parent._no_branch
+
+    @cached_property
+    def tier(self):
+        for tier in self._parent.tiers:
+            if tier.tag in self.tags:
+                return tier
+        return self._parent._no_tier
+
+    @cached_property
+    def is_stable(self):
+        return 'stable' in self.tags
+
+    @cached_property
+    def is_release_blocking(self):
+        return self.tier.value in (1, 2)
+
+    def __lt__(self, other):
+        return self["name"] < other["name"]
+
+    def iter_interesting_builds(self):
+        """Yield builds except unfinished/skipped/interrupted ones"""
+        for build in self.builds:
+            if build["results"] in (
+                buildbot.process.results.SUCCESS,
+                buildbot.process.results.WARNINGS,
+                buildbot.process.results.FAILURE,
             ):
-                if not worker["connected_to"]:
-                    disconnected_workers[worker["name"]] = worker
+                yield build
 
-            branch = None
-            tier = 'no tier'
-            for tag in builder["tags"]:
-                if "3." in tag:
-                    branch = tag
-                if tag.startswith('tier-'):
-                    tier = tag
+    @cached_sorted_property()
+    def problems(self):
+        latest_build = None
+        for build in self.iter_interesting_builds():
+            latest_build = build
+            break
 
-            if not branch:
-                continue
+        if not latest_build:
+            yield NoBuilds(self)
+            return
+        elif latest_build["results"] == buildbot.process.results.WARNINGS:
+            yield BuildWarning(latest_build)
+        elif latest_build["results"] == buildbot.process.results.FAILURE:
+            failing_streak = 0
+            first_failing_build = None
+            for build in self.iter_interesting_builds():
+                if build["results"] == buildbot.process.results.FAILURE:
+                    first_failing_build = build
+                    continue
+                elif build["results"] == buildbot.process.results.SUCCESS:
+                    if latest_build != first_failing_build:
+                        yield BuildFailure(latest_build, first_failing_build)
+                    break
+            else:
+                yield BuildFailure(latest_build)
 
-            failed_builds_by_tier = failed_builds_by_branch_and_tier.setdefault(branch, {})
+        if not self.connected_workers:
+            yield BuilderDisconnected(self)
 
-            endpoint = ("builders", builder["builderid"], "builds")
-            last_build = release_status_app.buildbot_api.dataGet(
-                endpoint,
-                limit=1,
-                order=["-complete_at"],
-                filters=[Filter("complete", "eq", ["True"])],
-            )
-            if not last_build:
-                continue
+    @cached_sorted_property
+    def connected_workers(self):
+        for worker in self._root.workers:
+            if worker["connected_to"]:
+                for cnf in worker["configured_on"]:
+                    if cnf["builderid"] == self["builderid"]:
+                        yield worker
 
-            (last_build,) = last_build
+class Worker(DashboardObject):
+    pass  # The JSON is fine! :)
 
-            if last_build["results"] != FAILED_BUILD_STATUS:
-                continue
+@total_ordering
+class _BranchTierBase(DashboardObject):
+    """Base class for Branch and Tag"""
+    # Branches have several kinds of names:
+    # 'tag': '3.x' (used as key)
+    # 'version': '3.14'
+    # 'branch': 'main'
+    # To prevent confusion, there's no 'name'
 
-            failed_builds = failed_builds_by_tier.setdefault(tier, [])
-            failed_builds.append((builder, last_build))
+    @cached_property
+    def tag(self):
+        return self["tag"]
 
-        def tier_sort_key(item):
-            tier, data = item
-            if tier == 'no tier':
-                return 'zzz'  # sort last
-            return tier
+    def __hash__(self):
+        return hash(self.tag)
 
-        failed_builders = []
-        for branch, failed_builds_by_tier in failed_builds_by_branch_and_tier.items():
-            failed_builders.append((
-                branch,
-                sorted(failed_builds_by_tier.items(), key=tier_sort_key)
-            ))
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.tag == other
+        return self.sort_key == other.sort_key
 
-        def branch_sort_key(item):
-            branch, *_ = item
-            minor = branch.split('.')[-1]
+    def __lt__(self, other):
+        return self.sort_key < other.sort_key
+
+    def __str__(self):
+        return self.tag
+
+@total_ordering
+class Branch(_BranchTierBase):
+    @cached_property
+    def sort_key(self):
+        if self.tag.startswith("3."):
             try:
-                return int(minor)
+                return (1, int(self.tag[2:]))
             except ValueError:
-                return 99
+                return (2, 99)
+        return (0, 0)
 
-        failed_builders.sort(reverse=True, key=branch_sort_key)
+    @cached_property
+    def title(self):
+        if self.tag == '3.x':
+            return 'main'
+        return self.tag
 
-        generated_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    @cached_sorted_property()
+    def problems(self):
+        problems = []
+        for builder in self._root.builders:
+            if builder.branch == self:
+                problems.extend(builder.problems)
+        return problems
+
+    @cached_property
+    def featured_problem(self):
+       try:
+        try:
+            return self.problems[0]
+        except IndexError:
+            return NoProblem()
+       except AttributeError:
+           raise SystemError
+
+    def get_grouped_problems(self):
+        def key(problem):
+            return problem.description
+        for d, problems in itertools.groupby(self.problems, key):
+            yield d, list(problems)
+
+
+class Tier(_BranchTierBase):
+    @cached_property
+    def value(self):
+        if self.tag.startswith("tier-"):
+            try:
+                return int(self.tag[5:])
+            except ValueError:
+                pass
+        return 99
+
+    @cached_property
+    def title(self):
+        return self.tag.title()
+
+    @cached_property
+    def sort_key(self):
+        return self.value
+
+    @cached_property
+    def is_release_blocking(self):
+        return self.value in {1, 2}
+
+
+class Build(DashboardObject):
+    @cached_property
+    def builder(self):
+        assert self._parent["builderid"] == self["builderid"]
+        return self._parent
+
+    @cached_property
+    def changes(self):
+        infos = self.dataGet(
+            ("builds", self["buildid"], "changes"),
+            limit=MAX_CHANGES,
+        )
+        if len(infos) == MAX_CHANGES:
+            # Buildbot lists changes since the last *successful* build,
+            # so in a failing streak the list can get very big.
+            # When this happens, it's probably better to pretend we don't have
+            # any info (which we'll also get when information is
+            # scrubbed after some months)
+            return []
+        return [Change(self, info) for info in infos]
+
+    @cached_property
+    def started_at(self):
+        if self["started_at"]:
+            return datetime.datetime.fromtimestamp(self["started_at"],
+                                                   tz=datetime.timezone.utc)
+
+    @cached_property
+    def age(self):
+        if self["started_at"]:
+            return self._root.now - self.started_at
+
+    @cached_property
+    def results_symbol(self):
+        if self["results"] == buildbot.process.results.FAILURE:
+            return '\N{HEAVY BALLOT X}'
+        if self["results"] == buildbot.process.results.WARNINGS:
+            return '\N{WARNING SIGN}'
+        if self["results"] == buildbot.process.results.SUCCESS:
+            return '\N{HEAVY CHECK MARK}'
+        if self["results"] == buildbot.process.results.SKIPPED:
+            return '\N{CIRCLED MINUS}'
+        if self["results"] == buildbot.process.results.EXCEPTION:
+            return '\N{CIRCLED DIVISION SLASH}'
+        if self["results"] == buildbot.process.results.RETRY:
+            return '\N{ANTICLOCKWISE OPEN CIRCLE ARROW}'
+        if self["results"] == buildbot.process.results.CANCELLED:
+            return '\N{CIRCLED TIMES}'
+        return str(self["results"])
+
+    @cached_property
+    def results_string(self):
+        return buildbot.process.results.statusToString(self["results"])
+
+    @cached_property
+    def css_color_class(self):
+        if self["results"] == buildbot.process.results.SUCCESS:
+            return 'success'
+        if self["results"] == buildbot.process.results.WARNINGS:
+            return 'warning'
+        if self["results"] == buildbot.process.results.FAILURE:
+            return 'danger'
+        return 'unknown'
+
+    @cached_property
+    def junit_results(self):
+        filepath = (
+            self._root._app.test_result_dir
+            / self.builder.branch.tag
+            / self.builder["name"]
+            / f'build_{self["number"]}.xml'
+        )
+        try:
+            file = filepath.open()
+        except OSError:
+            return None
+        with file:
+            etree = ElementTree.parse(file)
+        result = JunitResult(self, {})
+        for element in etree.iterfind('.//error/..'):
+            result.add(element)
+        return result
+
+    @cached_property
+    def duration(self):
+        try:
+            seconds = (
+                self["complete_at"]
+                - self["started_at"]
+                - self["locks_duration_s"]
+            )
+        except (KeyError, TypeError):
+            return None
+        return datetime.timedelta(seconds=seconds)
+
+
+class JunitResult(DashboardObject):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.contents = {}
+        self.errors = []
+        self.error_types = set()
+
+    def add(self, element):
+        errors = []
+        error_types = set()
+        for error_elem in element.iterfind('error'):
+            new_error = JunitError(self, {
+                **error_elem.attrib,
+                'text': error_elem.text,
+            })
+            errors.append(new_error)
+            error_types.add(new_error["type"])
+        result = self
+        name_parts = element.attrib.get('name', '??').split('.')
+        if name_parts[0] == 'test':
+            name_parts.pop(0)
+        for part in name_parts:
+            result.error_types.update(error_types)
+            result = result.contents.setdefault(part, JunitResult(self, {}))
+        result.error_types.update(error_types)
+        for error in errors:
+            if error not in result.errors:
+                # De-duplicate, since failing tests are re-run and often fail
+                # the same way
+                result.errors.extend(errors)
+
+
+class JunitError(DashboardObject):
+    def __eq__(self, other):
+        return self._info == other._info
+
+
+class Change(DashboardObject):
+    pass
+
+
+class Severity(enum.IntEnum):
+    # "Headings" and concrete values are all sortable enum items
+
+    NO_PROBLEM = enum.auto()
+    no_builds_yet = enum.auto()
+    disconnected_unstable_builder = enum.auto()
+    unstable_warnings = enum.auto()
+    unstable_builder_failure = enum.auto()
+
+    TRIVIAL = enum.auto()
+    stable_warnings = enum.auto()
+    disconnected_stable_builder = enum.auto()
+    disconnected_blocking_builder = enum.auto()
+
+    CONCERNING = enum.auto()
+    nonblocking_failure = enum.auto()
+
+    BLOCKING = enum.auto()
+    release_blocking_failure = enum.auto()
+
+    @cached_property
+    def css_color_class(self):
+        if self >= Severity.BLOCKING:
+            return 'danger'
+        if self >= Severity.CONCERNING:
+            return 'warning'
+        return 'success'
+
+    @cached_property
+    def symbol(self):
+        if self >= Severity.BLOCKING:
+            return '\N{HEAVY BALLOT X}'
+        if self >= Severity.CONCERNING:
+            return '\N{WARNING SIGN}'
+        return '\N{HEAVY CHECK MARK}'
+
+    @cached_property
+    def releasability(self):
+        if self >= Severity.BLOCKING:
+            return 'Unreleasable'
+        if self >= Severity.CONCERNING:
+            return 'Concern'
+        return 'Releasable'
+
+
+class Problem:
+    def __str__(self):
+        return self.description
+
+    @cached_property
+    def order_key(self):
+        return -self.severity, self.description
+
+    def __eq__(self, other):
+        return self.order_key == other.order_key
+
+    def __lt__(self, other):
+        return self.order_key < other.order_key
+
+    @cached_property
+    def severity(self):
+        self.severity, self.description = self.get_severity_and_description()
+        return self.severity
+
+    @cached_property
+    def description(self):
+        self.severity, self.description = self.get_severity_and_description()
+        return self.description
+
+    @property
+    def affected_builds(self):
+        return {}
+
+
+@dataclass
+class BuildFailure(Problem):
+    """The most recent build failed"""
+    latest_build: Build
+    first_failing_build: 'Build | None' = None
+
+    def get_severity_and_description(self):
+        if not self.builder.is_stable:
+            return Severity.unstable_builder_failure, "Unstable build failed"
+        if self.builder.is_release_blocking:
+            severity = Severity.release_blocking_failure
+        else:
+            severity = Severity.nonblocking_failure
+        description = f"{self.builder.tier.title} build failed"
+        return severity, description
+
+    @property
+    def builder(self):
+        return self.latest_build.builder
+
+    @cached_property
+    def affected_builds(self):
+        result = {"Latest build": self.latest_build}
+        if self.first_failing_build:
+            result["Breaking build"] = self.first_failing_build
+        return result
+
+
+@dataclass
+class BuildWarning(Problem):
+    """The most recent build warns"""
+    build: Build
+
+    def get_severity_and_description(self):
+        # Description word order is different from BuildFailure, to tell these
+        # apart at a glance
+        if not self.builder.is_stable:
+            return Severity.unstable_warnings, "Warnings from unstable build"
+        severity = Severity.stable_warnings
+        description = f"Warnings from {self.builder.tier.title} build"
+        return severity, description
+
+    @property
+    def builder(self):
+        return self.build.builder
+
+    @cached_property
+    def affected_builds(self):
+        return {"Warning build": self.build}
+
+
+@dataclass
+class NoBuilds(Problem):
+    """Builder has no finished builds yet"""
+    builder: Builder
+
+    description = "Builder has no builds"
+    severity = Severity.no_builds_yet
+
+
+@dataclass
+class BuilderDisconnected(Problem):
+    """Builder has no finished builds yet"""
+    builder: Builder
+
+    def get_severity_and_description(self):
+       try:
+        if not self.builder.is_stable:
+            severity = Severity.disconnected_unstable_builder
+            description = "Disconnected unstable builder"
+        else:
+            description = f"Disconnected {self.builder.tier.title} builder"
+            if self.builder.is_release_blocking:
+                severity = Severity.disconnected_blocking_builder
+            else:
+                severity = Severity.disconnected_stable_builder
+        for build in self.builder.iter_interesting_builds():
+            if build.age and build.age < datetime.timedelta(hours=6):
+                description += ' (with recent build)'
+                if severity >= Severity.BLOCKING:
+                    severity = Severity.CONCERNING
+                if severity >= Severity.CONCERNING:
+                    severity = Severity.TRIVIAL
+            break
+        return severity, description
+       except:
+           raise SystemError
+
+
+class NoProblem(Problem):
+    """Dummy problem"""
+    name = "Releasable"
+
+    description = "No problem detected"
+    severity = Severity.NO_PROBLEM
+
+
+class ReleaseDashboard:
+    # This doesn't get recreated for every render.
+    # The Flask app and caches go here.
+    def __init__(self, test_result_dir=None):
+        self.flask_app = Flask("test", root_path=os.path.dirname(__file__))
+        self.cache = None
+
+        self._refresh_branch_info()
+
+        self.flask_app.jinja_env.add_extension('jinja2.ext.loopcontrols')
+        self.flask_app.jinja_env.undefined = jinja2.StrictUndefined
+
+        self.test_result_dir = Path(test_result_dir)
+
+        @self.flask_app.route('/')
+        @self.flask_app.route("/index.html")
+        def main():
+            force_refresh = request.args.get("refresh", "").lower() in {"1", "yes", "true"}
+
+            if self.cache is not None and not force_refresh:
+                result, deadline = self.cache
+                if time.monotonic() <= deadline:
+                    return result
+
+                try:
+                    self._refresh_branch_info()
+                except urllib.error.HTTPError:
+                    pass
+
+            result = self.get_release_status()
+            deadline = time.monotonic() + CACHE_DURATION
+            self.cache = (result, deadline)
+            return result
+
+        @self.flask_app.template_filter('first_line')
+        def first_line(text):
+            return text.partition('\n')[0]
+
+        @self.flask_app.template_filter('committer_name')
+        def committer_name(text):
+            return text.partition(' <')[0]
+
+        @self.flask_app.template_filter('format_datetime')
+        def format_timestamp(dt):
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            ago = humanize.naturaldelta(now - dt)
+            return f'{dt:%Y-%m-%d %H:%M:%S}, {ago} ago'
+
+        @self.flask_app.template_filter('format_timedelta')
+        def format_timedelta(delta):
+            return humanize.naturaldelta(delta)
+
+        @self.flask_app.template_filter('short_rm_name')
+        def short_rm_name(full_name):
+            # DEBT: this assumes the first word of a release manager's name
+            # is a good way to call them.
+            # When that's no longer true we should put a name in the data.
+            return full_name.split()[0]
+
+    def _refresh_branch_info(self):
+        with urllib.request.urlopen(BRANCHES_URL) as file:
+            self.branch_info = json.load(file)
+
+    def get_release_status(self):
+        state = DashboardState(self)
 
         return render_template(
             "releasedashboard.html",
-            failed_builders=failed_builders,
-            generated_at=generated_at,
-            disconnected_workers=sorted(disconnected_workers.items()),
+            state=state,
+            Severity=Severity,
+            generated_at=state.now,
         )
 
-    @release_status_app.route("/index.html")
-    def main():
-        nonlocal cache
-
-        force_refresh = request.args.get("refresh", "").lower() in {"1", "yes", "true"}
-
-        if cache is not None and not force_refresh:
-            result, deadline = cache
-            if time.monotonic() <= deadline:
-                return result
-
-        result = get_release_status()
-        deadline = time.monotonic() + CACHE_DURATION
-        cache = (result, deadline)
-        return result
-
-    return release_status_app
+def get_release_status_app(buildernames=None, **kwargs):
+    return ReleaseDashboard(**kwargs).flask_app

--- a/master/custom/static/dashboard.css
+++ b/master/custom/static/dashboard.css
@@ -8,6 +8,7 @@
     width: 90%;
     max-width: 1200px;
     margin: 20px auto 0;
+    font-family: 'Arial', sans-serif;
 
     .header {
         text-align: center;
@@ -121,6 +122,7 @@
             text-align: center;
             font-size: 75%;
             box-shadow: rgba(0, 0, 0, 0.15) 0px 5px 3px -2px inset;
+            line-height: 1.5;
         }
     }
 

--- a/master/custom/static/dashboard.css
+++ b/master/custom/static/dashboard.css
@@ -1,9 +1,234 @@
+.release_status {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 20px;
+    margin-top: 20px;
+
+    width: 90%;
+    max-width: 1200px;
+    margin: 20px auto 0;
+
+    .header {
+        text-align: center;
+        margin-bottom: 30px;
+    }
+
+    .header img {
+        max-width: 100%;
+        height: auto;
+        animation: fadeIn 1s ease-out;
+    }
+
+    h1, h2 {
+        color: var(--primary-color);
+    }
+
+    h1 {
+        font-size: 2.5em;
+        margin-top: 20px;
+        margin-bottom: 2rem;
+    }
+
+    h2 {
+        font-size: 2em;
+        padding-bottom: 10px;
+        margin-top: 40px;
+    }
+
+    section {
+        padding-left: 1.5rem;
+    }
+    h3, h4, h5, h6 {
+        section > & {
+            margin-left: -1.5rem;
+        }
+    }
+
+    .branch-panels {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+        align-items: stretch;
+        justify-content: center;
+    }
+    .branch-panel {
+        cursor: pointer;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        height: 100%;
+        min-width: 9rem;
+        max-width: 13rem;
+
+        display: flex;
+        flex-direction: column;
+        * { flex-grow: 0; }
+
+        &:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        }
+        .releasability {
+            font-weight: bold;
+            -color: var(--text-color);
+                .panel-success & {
+                    color: var(--success-color);
+                }
+                .panel-warning & {
+                    color: var(--warning-color);
+                }
+                .panel-danger & {
+                    color: var(--danger-color);
+                }
+        }
+
+        .panel-heading {
+            padding: 15px 15px 15px;
+            font-weight: bold;
+            text-align: center;
+            box-shadow: rgba(0, 0, 0, 0.15) 0px -5px 3px -2px inset;
+            color: white;
+
+            h3 {
+                font-size: 3rem;
+                padding: 0;
+                margin: 0;
+            }
+
+            .panel-success & {
+                background-color: var(--success-color);
+            }
+            .panel-warning & {
+                background-color: var(--warning-color-bg);
+            }
+            .panel-danger & {
+                background-color: var(--danger-color);
+            }
+        }
+
+        .panel-body {
+            padding: 10px;
+            background-color: white;
+            text-align: center;
+            flex-grow: 2;
+        }
+
+        .panel-footer {
+            background-color: var(--pill-bg-color);
+            padding: 10px 15px 7px;
+            text-align: center;
+            font-size: 75%;
+            box-shadow: rgba(0, 0, 0, 0.15) 0px 5px 3px -2px inset;
+        }
+    }
+
+    section.branch-status {
+        --status-color: var(--background-color);
+        border-radius: 20px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 2px 4px color-mix(in srgb, var(--status-color) 20%, color-mix(in srgb, var(--background-color) 50%, transparent));
+        border-left: 2px solid var(--status-color);
+        overflow: clip;
+        h3 {
+            padding-left: 1rem;
+            background-color: var(--status-color);
+            color: var(--background-color);
+            position: sticky;
+            top: 0;
+            z-index: 9;
+        }
+        margin-bottom: 1rem;
+        h4.tier-name {
+            font-weight: normal;
+            font-size: 100%;
+        }
+        & > section {
+            padding-bottom: 0.5rem;
+        }
+        h5 {
+            margin-bottom: 0;
+        }
+        &:empty {
+            padding-bottom: 0;
+            border-color: transparent;
+            h3 {
+                border-radius: 20px;
+            }
+        }
+
+        &.status-success { --status-color: var(--success-color); }
+        &.status-warning { --status-color: var(--warning-color); }
+        &.status-danger { --status-color: var(--danger-color); }
+        .build-dots {
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        .build-dot {
+            display: inline-block;
+            margin: 0px;
+            width: 1rem;
+            height: 1rem;
+            background-color: var(--pill-bg-color);
+            color: var(--pill-text-color);
+            font-size: .75rem;
+            line-height: 1rem;
+            border-radius: .5rem;
+            padding: 0 0 .4rem;
+            text-align: center;
+            vertical-align: .125rem;
+            &.build-results-success { background-color: var(--success-color); color: white; }
+            &.build-results-warning { background-color: var(--warning-color-bg); }
+            &.build-results-danger { background-color: var(--danger-color); color: white; }
+        }
+        .tag {
+            display: inline-block;
+            background-color: var(--pill-bg-color);
+            color: var(--pill-text-color);
+            font-size: .7rem;
+            border-radius: .5rem;
+            padding: .2em .5em .3em;
+        }
+        .junit-result {
+            > .junit-result {
+                margin-left: 2rem;
+            }
+            &[open] > summary .exception-summary {
+                display: none;
+            }
+            .exception-summary code:before {
+                content: ' 🞬 ';
+                color: var(--danger-color);
+                font-family: var(--font-family-sans-serif);
+            }
+        }
+        .junit-error {
+            margin-left: 2rem;
+            summary:before {
+                content: '🞬 ';
+                color: var(--danger-color);
+            }
+            pre {
+                padding: .5rem;
+                border-radius: .25rem;
+                margin-right: 1rem;
+                background-color: var(--pill-bg-color);
+                border: 1px solid rgba(0, 0, 0, .2);
+                box-shadow: rgba(0, 0, 0, .2) 0px 1px 2px -1px inset;
+            }
+        }
+    }
+}
+
 :root {
     --primary-color: #306998;
     --secondary-color: #FFD43B;
     --background-color: #f4f4f4;
     --text-color: #333;
-    --success-color: #4CAF50;
+    --success-color: #4CAF60;
+    --warning-color: #C2870F;
+    --warning-color-bg: #E4B615; /* nicer "traffic light" amber , but not enough contrast for text */
     --danger-color: #f44336;
     --pill-bg-color: #e0e0e0;
     --pill-text-color: #333;
@@ -19,168 +244,9 @@ body {
     margin: 0;
     padding: 0;
     transition: all 0.3s ease;
+    scroll-behavior: smooth;
 }
 
-.container {
-    width: 90%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 20px;
-}
-
-.release_status {
-    background-color: white;
-    border-radius: 10px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    padding: 20px;
-    margin-top: 20px;
-}
-
-.header {
-    text-align: center;
-    margin-bottom: 30px;
-}
-
-.header img {
-    max-width: 100%;
-    height: auto;
-    animation: fadeIn 1s ease-out;
-}
-
-h1, h2 {
-    color: var(--primary-color);
-}
-
-h1 {
-    font-size: 2.5em;
-    margin-top: 20px;
-}
-
-h2 {
-    font-size: 2em;
-    border-bottom: 2px solid var(--secondary-color);
-    padding-bottom: 10px;
-    margin-top: 40px;
-}
-
-.row {
-    display: flex;
-    flex-wrap: wrap;
-    margin: -10px;
-}
-
-.col-md-4 {
-    flex: 0 0 calc(33.333% - 20px);
-    margin: 10px;
-}
-
-.panel {
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.panel:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.panel-heading {
-    padding: 15px;
-    font-weight: bold;
-    text-align: center;
-}
-
-.panel-success .panel-heading {
-    background-color: var(--success-color);
-    color: white;
-}
-
-.panel-danger .panel-heading {
-    background-color: var(--danger-color);
-    color: white;
-}
-
-.panel-body {
-    padding: 20px;
-    background-color: white;
-}
-
-.badge {
-    display: inline-block;
-    padding: 8px 12px;
-    border-radius: 20px;
-    margin: 5px 0;
-    text-decoration: none;
-    font-weight: bold;
-    transition: all 0.3s ease;
-    background-color: var(--pill-bg-color);
-    color: var(--pill-text-color);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.badge:hover {
-    background-color: var(--pill-hover-bg-color);
-    color: var(--pill-hover-text-color);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.badge-status {
-    animation: fadeInUp 0.5s ease-out;
-}
-
-.results_FAILURE {
-    background-color: var(--danger-color);
-    color: white;
-}
-
-.results_SUCCESS {
-    background-color: var(--success-color);
-    color: white;
-}
-
-.fa-check {
-    font-size: 48px;
-    color: var(--success-color);
-    animation: pulse 2s infinite;
-}
-
-.tier-title {
-    font-size: 1.2em;
-    color: var(--primary-color);
-    border-bottom: 2px solid var(--secondary-color);
-    padding-bottom: 5px;
-    margin-top: 20px;
-    margin-bottom: 10px;
-    font-weight: bold;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-@keyframes pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.1); }
-    100% { transform: scale(1); }
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@media (max-width: 768px) {
-    .col-md-4 {
-        flex: 0 0 100%;
-    }
+code {
+    color: inherit;
 }

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -1,80 +1,227 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Python Branch Release Status Dashboard</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
-    <link href="{{ url_for('static', filename='dashboard.css') }}" rel="stylesheet">
-</head>
-<body>
-    <div class="container release_status">
-        <div class="header">
-            <img src="https://www.python.org/static/community_logos/python-logo-master-v3-TM.png" alt="Python Logo" width="480" height="162">
-            <h1>Branch Release Status Dashboard</h1>
-        </div>
-        <h2>Failing Stable Builders</h2>
-        <div class="row">
-            {% for branch, info_by_tier in failed_builders %}
-                <div class="col-md-4">
-                    {% if not info_by_tier %}
-                        <div class="panel panel-success">
-                            <div class="panel-heading">
-                                <h4 class="panel-title">
-                                    Branch {{ branch }} status: Releasable
-                                </h4>
-                            </div>
-                            <div class="panel-body">
-                                <div style="text-align: center;">
-                                    <i class="fas fa-check"></i>
-                                </div>
-                            </div>
+{% macro build_dot(build) -%}
+    <a
+        href="#/builders/{{build.builderid}}/builds/{{ build.number }}"
+        class="build-dot build-results-{{ build.css_color_class }}"
+        title="{{ build_summary(build) }}"
+    >
+        {{ build.results_symbol }}
+    </a>
+{% endmacro -%}
+{%- macro build_summary(build) -%}
+    #{{- build.number -}}
+    {{- ' ' -}}
+    (
+        {{- build.results_string -}},
+        {{- ' ' -}}
+        {{- build.started_at | format_datetime -}}
+        {%- if build.duration -%}
+            ; took {{ build.duration | format_timedelta -}}
+        {%- endif -%}
+    )
+{%- endmacro -%}
+{% macro build_info(build) -%}
+    {{ build_dot(build) }}
+    {{ build_summary(build) }}
+    {% if build.builder.is_stable %}
+        {% if build.junit_results %}
+            {% for name, result in build.junit_results.contents.items() %}
+                {{ junit_result(build.junit_results, name, toplevel=True) }}
+            {% endfor %}
+        {% endif %}
+        {% if build.changes %}
+            <details {% if build.changes|length <= 3 %}open{% endif %}>
+                <summary>
+                    {{ build.changes|length }}
+                    change{% if build.changes|length != 1 %}s{% endif %}
+                </summary>
+                <ul>
+                    {% for change in build.changes %}
+                        <li>
+                            <a href="{{ change.revlink }}" title="{{ change }}">
+                                {{ change.comments | first_line }}
+                            </a>
+                            by {{ change.author | committer_name }}
+                            {% if change.files %}
+                                <details {% if change.files|length <= 3 %}open{% endif %}>
+                                    <summary>
+                                        {{ change.files|length }}
+                                        file{% if change.files|length != 1 %}s{% endif %}
+                                        changed
+                                    </summary>
+                                    <ul>
+                                        {% for file in change.files %}
+                                            <li>
+                                                {{ file }}
+                                            </li>
+                                        {% endfor  %}
+                                    </ul>
+                                </details>
+                            {% endif %}
+                        </li>
+                    {% endfor -%}
+                </ul>
+            </details>
+        {% endif -%}
+    {% endif -%}
+{% endmacro -%}
+{% macro junit_result(result, name, toplevel=False) %}
+    {% if (result.contents | length == 1) and (not result.errors) %}
+        {% for cname, child in result.contents.items() %}
+            {{ junit_result(
+                child,
+                name + ('.' if name else '') + cname,
+                toplevel=toplevel,
+            ) }}
+        {% endfor %}
+    {% else %}
+        <details {% if not toplevel %}open{% endif %} class="junit-result">
+            <summary>
+                <code>{{ name }}</code>
+                <span class="exception-summary">
+                    (
+                    {%- for type in result.error_types | sort -%}
+                        {%- if loop.index > 3 -%}
+                            ...
+                            {% break %}
+                        {%- endif -%}
+                        <code>{{ type }}</code>
+                        {%- if not loop.first %}, {% endif -%}
+                    {%- endfor -%}
+                    )
+                </span>
+            </summary>
+            {% for error in result.errors %}
+                <details class="junit-error">
+                    <summary><code>{{ error.type }}</code></summary>
+                    <pre class="junit-traceback">{{ error.text }}</pre>
+                </details>
+            {% endfor %}
+            {% for cname, child in result.contents.items() %}
+                {{ junit_result(child, cname) }}
+            {% endfor %}
+        </details>
+    {% endif %}
+{% endmacro %}
+
+<div class="container release_status">
+    <div style="text-align: center;">
+        <h1>Python Release Status Dashboard</h1>
+    </div>
+
+    <div class="branch-panels">
+        {% for branch in state.branches %}
+            {% if branch.tag == 'no-branch' %}
+                {% continue %}
+            {% endif %}
+            <div
+                class="branch-panel panel-{{ branch.featured_problem.severity.css_color_class }}"
+                {#- Buildbot's React UI takes over `#` in the URL, so a HTML fragment link won't work here...  #}
+                onclick="document.getElementById('branch-section-{{branch}}').scrollIntoView();"
+            >
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        {{ branch.version }}
+                    </h3>
+                </div>
+                <div class="panel-body">
+                    <div class="releasability">
+                        <span class="severity-symbol">
+                            {{ branch.featured_problem.severity.symbol }}
+                        </span>
+                        {{ branch.featured_problem.severity.releasability }}
+                    </div>
+                    {{ branch.featured_problem }}
+                </div>
+                <div class="panel-footer">
+                    <div>
+                        {{ branch.status | title }} branch
+                        <code>{{ branch.branch }}</code>
+                    </div>
+                    {% if branch.pep is defined %}
+                        <div>
+                            Schedule:
+                            <a href="https://peps.python.org/pep-{{ branch.pep }}/">
+                                PEP {{ branch.pep }}
+                            </a>
                         </div>
-                    {% else %}
-                        <div class="panel panel-danger">
-                            <div class="panel-heading">
-                                <h4 class="panel-title">
-                                    Branch {{ branch }} status:
-                                </h4>
-                            </div>
-                            <div class="panel-body">
-                                {% for tier, info in info_by_tier %}
-                                    <div class="tier-title">{{ tier }}</div>
-                                    {% for builder, build in info %}
-                                        <div>
-                                            <a class="badge badge-status results_{{build.results_text | upper}}"
-                                               href="#/builders/{{build.builderid}}/builds/{{build.number}}">
-                                                {{ builder.name }}: #{{ build.number }}
-                                            </a>
-                                        </div>
-                                    {% endfor %}
-                                {% endfor %}
-                            </div>
+                    {% endif %}
+                    {% if branch.release_manager is defined %}
+                        <div>
+                            <abbr title="Release Manager">RM</abbr>:
+                            {{ branch.release_manager | short_rm_name }}
                         </div>
                     {% endif %}
                 </div>
-            {% endfor %}
-        </div>
-        <h2>Disconnected Stable Workers</h2>
-        <div class="container">
-            {% for name, worker in disconnected_workers %}
-                <div class="row">
-                    <a href="#/workers/{{ worker.workerid }}">
-                        {{ name }}
-                    </a>
-                </div>
-            {% else %}
-                None.
-            {% endfor %}
-        </div>
-        <div class="container">
-            <small>Generated at <time id="generatedAt" datetime="{{generated_at}}">{{generated_at}}</time></small>
-        </div>
+            </div>
+        {% endfor %}
     </div>
-    <script>
-        let elem = document.getElementById("generatedAt");
-        let date = new Date(elem.dateTime);
-        elem.innerText = date.toLocaleDateString("en-CA") + " " + date.toLocaleTimeString("pl-PL");
-    </script>
-</body>
-</html>
+
+    <h2>Problems by Branch</h2>
+
+    {% for branch in state.branches %}
+        <section class="branch-status status-{{ branch.featured_problem.severity.css_color_class }}" id="branch-section-{{branch}}">
+            <h3>
+                {{ branch.title }}
+                {% if branch.version is defined and branch.version != branch.title %}
+                    ({{ branch.version }})
+                {% endif %}
+            </h3>
+            {% for description, problems in branch.get_grouped_problems() %}
+                <details {% if problems[0].severity > Severity.TRIVIAL %}open{% endif %}>
+                    <summary class="tier-name">
+                        {{ description }} ({{ problems|length }})
+                    </summary>
+                    <section>
+                        {% for problem in problems %}
+                            <section>
+                                {% if problem.builder is defined %}
+                                    {% set builder = problem.builder %}
+                                    <h5>
+                                        <a href="#/builders/{{builder.builderid}}">
+                                            {{ builder.name -}}
+                                        </a>
+                                        {% for tag in builder.tags %}
+                                            <span class="tag">
+                                                {{ tag }}
+                                            </span>
+                                        {% endfor %}
+                                    </h5>
+                                    {% if not builder.connected_workers %}
+                                        <div>
+                                            Disconnected! 🔌
+                                            {% if builder.builds %}
+                                                Last build
+                                                {{ builder.builds[0].started_at | format_datetime }}
+                                            {% endif %}
+                                        </div>
+                                    {% endif %}
+                                    <div class="build-dots">
+                                        {% for build in builder.builds %}
+                                            {{ build_dot(build) }}
+                                        {% endfor %}
+                                    </div>
+                                    {% for label, build in problem.affected_builds.items() %}
+                                        <div>
+                                            {{ label }}: {{ build_info(build) }}
+                                        </div>
+                                    {% endfor %}
+                                {% else %}
+                                    {{ problem }}
+                                {% endif %}
+                            </section>
+                        {% endfor %}
+                    </section>
+                </details>
+            {% endfor %}
+        </section>
+    {% endfor %}
+
+    <div class="container">
+        <small>Generated at <time id="generatedAt" datetime="{{generated_at}}">{{generated_at}}</time></small>
+    </div>
+</div>
+<script>
+    let elem = document.getElementById("generatedAt");
+    let date = new Date(elem.dateTime);
+    elem.innerText = date.toLocaleDateString("en-CA") + " " + date.toLocaleTimeString("pl-PL");
+</script>

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -1,3 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Python Branch Release Status Dashboard</title>
+    <link href="{{ url_for('static', filename='dashboard.css') }}" rel="stylesheet">
+</head>
+<body>
+
 {% macro build_dot(build) -%}
     <a
         href="#/builders/{{build.builderid}}/builds/{{ build.number }}"
@@ -225,3 +235,6 @@
     let date = new Date(elem.dateTime);
     elem.innerText = date.toLocaleDateString("en-CA") + " " + date.toLocaleTimeString("pl-PL");
 </script>
+
+</body>
+</html>

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -85,7 +85,7 @@
                             {% break %}
                         {%- endif -%}
                         <code>{{ type }}</code>
-                        {%- if not loop.first %}, {% endif -%}
+                        {%- if not loop.last %}, {% endif -%}
                     {%- endfor -%}
                     )
                 </span>

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -196,7 +196,7 @@
                                         </div>
                                     {% endif %}
                                     <div class="build-dots">
-                                        {% for build in builder.builds %}
+                                        {% for build in builder.builds[:70] %}
                                             {{ build_dot(build) }}
                                         {% endfor %}
                                     </div>

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -514,7 +514,9 @@ c['www']['plugins']['wsgi_dashboards'] = [
     {
         'name': 'release_status',
         'caption': 'Release Status',
-        'app': get_release_status_app(release_status_builders),
+        'app': get_release_status_app(
+            release_status_builders,
+            test_result_dir='/data/www/buildbot/test-results/'),
         'order': 2,
         'icon': 'rocket'
     }

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 buildbot[bundle,tls]
 buildbot_wsgi_dashboards
 flask
+humanize
 PyYAML
 requests
 treq

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ croniter==3.0.3
 cryptography==43.0.1
 Flask==3.0.3
 greenlet==3.1.1
+humanize==4.11.0
 hyperlink==21.0.0
 idna==3.10
 importlib_metadata==8.5.0


### PR DESCRIPTION
I've spent some time making the Release Dashboard closer to my daily status reports (and include the info needed for them). Here's the result.

![image](https://github.com/user-attachments/assets/5323570e-dde3-4caf-a9bb-ea433b2da71f)

Outdated static demo: https://encukou.github.io/buildbot-status-dashboard/
WIP repo, with caching and hacks needed to iterate on this locally: https://github.com/encukou/buildbot-status-dashboard

Technically it *should* be drop-in upgrade for the existing dashboard, and that's what this PR does. But I now think it would be better to have both, at least for a while, in case this falls over. But, code is here.

Does this look reasonable?

---

Quick branch info (status, RM name, release schedule link) for all branches at the top, with detailed per-branch sections after that.
Details can generally be expanded/collapsed.

Show tier-3+ failures: these aren't considered release-blocking but we tend to fix these ASAP. These mark a "green" branch/builder as "yellow".

Show low-priority problems: disconnected builders, build warnings, unstable builder failures. These don't affect the overall status.

Show changes and test results for failing builds (when available).

Show build history overview for builders; this is useful context.

Conceptually, the branch sections list "problems", not builders, in preparation for adding blocker issues from GitHub. Problems are sorted by severity & grouped by type; the highest-severity problem determines the overall branch status.

Pull Request builders are, for now, shown in a `no-branch` section (hiding at the end with no link to it).

Based on Pablo's existing dashboard and his BuildbotHammer tool.