### PR TITLE
Fixes for diegorusso-aarch64-bigmem

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -20,6 +20,7 @@ from functools import partial
 from buildbot.plugins import reporters, schedulers, util
 from buildbot import locks
 from twisted.python import log
+from twisted.internet import defer
 
 import sentry_sdk
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -211,12 +212,13 @@ def no_builds_between(start, end):
         if is_within_time_range(now, start, end):
             delay = get_delay(now, end)
             # Schedule the build later
+            deferred = defer.Deferred()
             builder.master.reactor.callLater(
                 int(delay),
-                builder.buildset_manager.submitBuildSet,
+                deferred.callback,
                 requests[0],
             )
-            return None
+            return deferred
         # Schedule the build now
         return requests[0]
     return f

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -205,10 +205,10 @@ def get_delay(now, end):
 # Avoid a build to be started between start and end time and delay such build
 # at end time
 def no_builds_between(start, end):
-    now = datetime.now().time()
     start = datetime.strptime(start, "%H:%M").time()
     end = datetime.strptime(end, "%H:%M").time()
     def f(builder, requests):
+        now = datetime.now().time()
         if is_within_time_range(now, start, end):
             delay = get_delay(now, end)
             # Schedule the build later


### PR DESCRIPTION
Follow-up to #546

- Get the current time when a build is requested, rather than when the config is first loaded
- Return a Deferred from nextBuild. By my reading of the [`nextBuild`](https://docs.buildbot.net/4.1.0/manual/configuration/builders.html#:~:text=nextBuild) and [`Deferred`](https://docs.twisted.org/en/stable/core/howto/defer.html) docs, this is the way to do it.