### PR TITLE
Increase timeout for slow tests on UnixBigMemBuild

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -267,6 +267,7 @@ class UnixBuildWithoutDocStrings(UnixBuild):
 class UnixBigmemBuild(UnixBuild):
     buildersuffix = ".bigmem"
     testFlags = ["-M60g", "-j4", "-uall,extralargefile"]
+    test_timeout = TEST_TIMEOUT * 4
     factory_tags = ["bigmem"]
 
 


### PR DESCRIPTION
`test_lzma` and `test_bigmem` require more time to be fully executed. Increase the default timeout to allow these tests to pass.