### PR TITLE
Use `util.Interpolate` for dynamically setting the path to the suppression file based on the build directory.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1276,7 +1276,7 @@ class ValgrindBuild(UnixBuild):
             "--gen-suppressions=all",
             "--track-origins=yes",
             "--trace-children=yes",
-            "--suppressions=./Misc/valgrind-python.supp",
+            util.Interpolate("--suppressions=%(prop:builddir)s/build/Misc/valgrind-python.supp"),
             "./python",
             "-m", "test",
             *self.testFlags,


### PR DESCRIPTION
Updated the `--suppressions` option in the `setup` method to use `util.Interpolate` for dynamically setting the path to the suppression file based on the build directory.