### PR TITLE
Remove parallelization for iOS runners.

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -282,7 +282,9 @@ def get_workers(settings):
             name="rkm-arm64-ios-simulator",
             tags=['iOS'],
             not_branches=['3.9', '3.10', '3.11', '3.12'],
-            parallel_builders=4,
+            # Starting/running simulators in parallel can be problematic;
+            # see python/cpython#129200
+            parallel_builders=1,
         ),
         cpw(
             name="mhsmith-android-aarch64",


### PR DESCRIPTION
Fixes python/cpython#129200.

The iOS testbed runner has a known issue with starting 2 runs near the same time. The runner starts a simulator; but it finds the ID of the simulator that has been started by generating a list of know simulators, and then waiting until another entry appears. This works fine until there are 2 test runs started at near the same time, and the runner is unable to identify which simulator this test run has started, and raises an error.

There runtime for a test run can also vary depending on how many runs are operating in parallel - in the best case, a run will take 15 minutes; however, I have also seen timeouts on a test run.

This PR removes parallelization from the iOS runner, which should resolve both issues.