### PR TITLE
Fix test-with-buildbots label handling

### DIFF
--- a/master/custom/pr_testing.py
+++ b/master/custom/pr_testing.py
@@ -84,7 +84,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
         url = payload["pull_request"]["comments_url"]
         username = payload["sender"]["login"]
         commit = payload["pull_request"]["head"]["sha"]
-        pr_number = payload["issue"]["number"]
+        pr_number = payload["pull_request"]["number"]
         yield http.post(
             url.replace(self.github_api_endpoint, ""),
             json={


### PR DESCRIPTION
Fixes #578, a bug introduced by #576 for #327.

I was mislead by the number extraction in another part of the file.
