### PR TITLE
Show tier in buildbot failure message

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -61,7 +61,7 @@ STABLE = "stable"
 # Tier-2 builder.
 UNSTABLE = "unstable"
 
-# https://peps.python.org/pep-0011/ defines Platfom Support Tiers
+# https://peps.python.org/pep-0011/ defines Platform Support Tiers
 TIER_1 = "tier-1"
 TIER_2 = "tier-2"
 TIER_3 = "tier-3"
@@ -329,6 +329,31 @@ def get_builders(settings):
         for name, worker_name, buildfactory in builders:
             all_builders.append((name, worker_name, buildfactory, stability, tier))
     return all_builders
+
+
+def get_builder_tier(builder: str) -> str:
+    # Strip trailing branch name
+    import re
+    builder = re.sub(r" 3\.[x\d]+$", "", builder)
+
+    for builders, tier in (
+        (STABLE_BUILDERS_TIER_1, TIER_1),
+        (STABLE_BUILDERS_TIER_2,TIER_2),
+        (STABLE_BUILDERS_TIER_3, TIER_3),
+        (STABLE_BUILDERS_NO_TIER, NO_TIER),
+        (UNSTABLE_BUILDERS_TIER_1, TIER_1),
+        (UNSTABLE_BUILDERS_TIER_2, TIER_2),
+        (UNSTABLE_BUILDERS_TIER_3, TIER_3),
+        (UNSTABLE_BUILDERS_NO_TIER, NO_TIER),
+    ):
+        for name, _, _ in builders:
+            if name == builder:
+                if tier == NO_TIER:
+                    return "no tier"
+                else:
+                    return tier
+
+    return "unknown tier"
 
 
 # Match builder name (excluding the branch name) of builders that should only

--- a/master/custom/discord_reporter.py
+++ b/master/custom/discord_reporter.py
@@ -17,12 +17,13 @@ from buildbot.util.giturlparse import giturlparse
 from buildbot.plugins import reporters
 from buildbot.reporters.utils import getDetailsForBuild
 
+from custom.builders import get_builder_tier
 from custom.testsuite_utils import get_logs_and_tracebacks_from_build
 
 MESSAGE = """\
 :warning: **Buildbot failure** :warning:
 
-The buildbot **{buildername}** has failed when building commit {sha}(https://github.com/python/cpython/commit/{sha}).
+The buildbot **{buildername}** ({tier}) has failed when building commit {sha}(https://github.com/python/cpython/commit/{sha}).
 
 You can take a look at the buildbot page here:
 
@@ -149,9 +150,11 @@ class DiscordReporter(reporters.HttpStatusPush):
         sha,
         logs,
     ):
+        buildername = build["builder"]["name"]
 
         message = MESSAGE.format(
-            buildername=build["builder"]["name"],
+            buildername=buildername,
+            tier=get_builder_tier(buildername),
             build_url=self._getURLForBuild(
                 build["builder"]["builderid"], build["number"]
             ),

--- a/master/custom/pr_reporter.py
+++ b/master/custom/pr_reporter.py
@@ -18,13 +18,14 @@ from buildbot.util.giturlparse import giturlparse
 from buildbot.plugins import reporters
 from buildbot.reporters.utils import getDetailsForBuild
 
+from custom.builders import get_builder_tier
 from custom.testsuite_utils import get_logs_and_tracebacks_from_build
 
 PR_MESSAGE = """\
 :warning::warning::warning: Buildbot failure :warning::warning::warning:
 ------------------------------------------------------------------------
 
-Hi! The buildbot **{buildername}** has failed when building commit {sha}.
+Hi! The buildbot **{buildername}** ({tier}) has failed when building commit {sha}.
 
 What do you need to do:
 
@@ -212,9 +213,11 @@ buildid), logLevel=logging.INFO)
         tracebacks=None,
         logs=None,
     ):
+        buildername = build["builder"]["name"]
 
         message = PR_MESSAGE.format(
-            buildername=build["builder"]["name"],
+            buildername=buildername,
+            tier=get_builder_tier(buildername),
             build_url=self._getURLForBuild(
                 build["builder"]["builderid"], build["number"]
             ),


### PR DESCRIPTION
Fixes https://github.com/python/buildmaster-config/issues/582.

I don't have a good way of testing this, I did so by putting this at the end of `builders.py` and ran `make check`:

```python
print(get_builder_tier("AMD64 Fedora Stable LTO + PGO"))
print(get_builder_tier("AMD64 Fedora Stable Clang Installed 3.x"))
print(get_builder_tier("aarch64 Fedora Stable Clang Installed 3.x"))
print(get_builder_tier("aarch64 Fedora Stable Clang Installed 3.11"))
print(get_builder_tier("aarch64 Fedora Stable Clang Installed 3.9"))
print(get_builder_tier("aarch64 RHEL8 LTO 3.13"))
print(get_builder_tier("AMD64 RHEL8 FIPS Only Blake2 Builtin Hash 3.x"))
print(get_builder_tier("PPC64LE Fedora Rawhide Clang Installed 3.x"))
```
And got:
```
tier-1
tier-2
tier-2
tier-2
tier-2
tier-2
no tier
tier-3
```
