### PR TITLE
Add colour to Buildbot output

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -63,7 +63,7 @@ class UnixBuild(BaseBuild):
     interpreterFlags = ""
     testFlags = ["-j2"]
     makeTarget = "all"
-    test_environ = {}
+    test_environ = {"FORCE_COLOR": 1}
     build_out_of_tree = False
 
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):


### PR DESCRIPTION
Like https://github.com/python/cpython/pull/129196, will help us find errors in logs more easily.