### PR TITLE
Prioritize bigmem tests on bigmem workers

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -268,7 +268,7 @@ class UnixBigmemBuild(UnixBuild):
     buildersuffix = ".bigmem"
     testFlags = [
         "-M60g", "-j4", "-uall,extralargefile",
-        "--proritize=test_bigmem,test_lzma,test_bz2,test_re,test_array"
+        "--prioritize=test_bigmem,test_lzma,test_bz2,test_re,test_array"
     ]
     test_timeout = TEST_TIMEOUT * 4
     factory_tags = ["bigmem"]
@@ -655,7 +655,7 @@ class Windows64BigmemBuild(BaseWindowsBuild):
     buildFlags = ["-p", "x64"]
     testFlags = [
         "-p", "x64", "-M33g", "-uall,extralargefile",
-        "--proritize=test_bigmem,test_lzma,test_bz2,test_array,test_hashlib,test_zlib"
+        "--prioritize=test_bigmem,test_lzma,test_bz2,test_array,test_hashlib,test_zlib"
     ]
     test_timeout = TEST_TIMEOUT * 4
     cleanFlags = ["-p", "x64"]

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -266,7 +266,10 @@ class UnixBuildWithoutDocStrings(UnixBuild):
 
 class UnixBigmemBuild(UnixBuild):
     buildersuffix = ".bigmem"
-    testFlags = ["-M60g", "-j4", "-uall,extralargefile"]
+    testFlags = [
+        "-M60g", "-j4", "-uall,extralargefile",
+        "--proritize=test_bigmem,test_lzma,test_bz2,test_re,test_array"
+    ]
     test_timeout = TEST_TIMEOUT * 4
     factory_tags = ["bigmem"]
 
@@ -650,7 +653,10 @@ class Windows64Build(BaseWindowsBuild):
 class Windows64BigmemBuild(BaseWindowsBuild):
     buildersuffix = ".bigmem"
     buildFlags = ["-p", "x64"]
-    testFlags = ["-p", "x64", "-M33g", "-uall,extralargefile"]
+    testFlags = [
+        "-p", "x64", "-M33g", "-uall,extralargefile",
+        "--proritize=test_bigmem,test_lzma,test_bz2,test_array,test_hashlib,test_zlib"
+    ]
     test_timeout = TEST_TIMEOUT * 4
     cleanFlags = ["-p", "x64"]
     factory_tags = ["win64", "bigmem"]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -320,10 +320,16 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
             locks=[cpulock.access("counting")],
         )
 
-        # This worker runs pyperformance at 12am. If a build is scheduled between
-        # 10pm and 2am, it will be delayed at 2am.
+        # This worker runs pyperformance at 12am UTC. If a build is scheduled between
+        # 10pm UTC and 2am UTC, it will be delayed to 2am UTC.
         if worker_name == "diegorusso-aarch64-bigmem":
             builder.canStartBuild = no_builds_between("22:00", "2:00")
+        
+        # This worker restarts every day at 9am UTC to work around issues stemming from
+        # failing bigmem tests trashing disk space and fragmenting RAM. Builds scheduled
+        # between 07:20am - 9:20am UTC will be delayed to 9:20am UTC.
+        if worker_name == "ambv-bb-win11":
+            builder.canStartBuild = no_builds_between("7:20", "9:20")
 
         c["builders"].append(builder)
 


### PR DESCRIPTION
This ensures those tests run first, shortening the entire run.

The test set to prioritize is a bit different between Unix and Windows, this is based on actual observed runtimes of those tests. I took tests that take >5 minutes to execute.

Unrelatedly, mark ambv-bb-win11 as unavailable between 7:20am UTC - 9:20am UTC so that it can restart in peace without interrupting running builds.