### PR TITLE
Stop testing 3.12 on `stan-raspbian`

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -186,6 +186,8 @@ def get_workers(settings):
             tags=['linux', 'unix', 'raspbian', 'debian', 'armv8',
                   'aarch64', 'arm'],
             parallel_tests=4,
+            # Tests fail with latin1 encoding
+            not_branches=['3.12']
         ),
         cpw(
             name="kulikjak-solaris-sparcv9",


### PR DESCRIPTION
Tests fail due to the system encoding, latin-1. These tests have been fixed for bugfix branches (main, 3.14, 3.13), but unfortunately there is nothing to be done for 3.12 now. Therefore, it is best to remove it entirely since the fail result is guaranteed.

Request; @zware 