### PR TITLE
Mark the Windows NoGIL PGO builder as stable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -90,6 +90,7 @@ STABLE_BUILDERS_TIER_1 = [
     ("AMD64 Windows11 Non-Debug", "ware-win11", Windows64ReleaseBuild),
     ("AMD64 Windows11 Refleaks", "ware-win11", Windows64RefleakBuild),
     ("AMD64 Windows Server 2022 NoGIL", "itamaro-win64-srv-22-aws", Windows64NoGilBuild),
+    ("AMD64 Windows PGO NoGIL", "itamaro-win64-srv-22-aws", Windows64PGONoGilBuild),
 
     # macOS x86-64 clang
     ("x86-64 macOS", "billenstein-macos", UnixBuild),
@@ -235,9 +236,6 @@ UNSTABLE_BUILDERS_TIER_1 = [
 
     # Windows MSVC
     ("AMD64 Windows PGO", "bolen-windows10", Windows64PGOBuild),
-
-    # Windows NoGIL
-    ("AMD64 Windows PGO NoGIL", "itamaro-win64-srv-22-aws", Windows64PGONoGilBuild),
 ]
 
 


### PR DESCRIPTION
It started out as unstable and was broken for a while, but it is healthy now, so let's move it to stable