### PR TITLE
Update path to WASI config.site in `Wasm32WasiCrossBuild` factory

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -880,9 +880,6 @@ class Wasm32WasiCrossBuild(UnixCrossBuild):
         # debug builds exhaust the limited call stack on WASI
         "--without-pydebug",
     ]
-    compile_environ = {
-        "CONFIG_SITE": "../../Tools/wasm/wasi/config.site-wasm32-wasi",
-    }
     host = "wasm32-unknown-wasi"
     host_configure_cmd = ["../../Tools/wasm/wasi-env", "../../configure"]
 


### PR DESCRIPTION
The config.site used for WASI cross builds that don't use `wasi.py` moved last month, and now lives at [Tools/wasm/wasi/config.site-wasm32-wasi](https://github.com/python/cpython/blob/main/Tools/wasm/wasi/config.site-wasm32-wasi). The path hasn't been updated in the builder though, so the config.site is not getting picked up for the cross builds.

Example failure: https://buildbot.python.org/#/builders/1373/builds/515