### PR TITLE
Allow setting custom buildfactory with local worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -334,7 +334,8 @@ UNSTABLE_BUILDERS_NO_TIER = [
 def get_builders(settings):
     # Override with a default simple worker if we are using local workers
     if settings.use_local_worker:
-        return [("Test Builder", "local-worker", UnixBuild, STABLE, NO_TIER)]
+        local_buildfactory = globals().get(settings.local_worker_buildfactory, UnixBuild)
+        return [("Test Builder", "local-worker", local_buildfactory, STABLE, NO_TIER)]
 
     all_builders = []
     for builders, stability, tier in (


### PR DESCRIPTION
Currently, the local worker unconditionally uses a UnixBuild. However, when working on changes to other factories, it is useful to be able to customize this in settings.yaml to run the builder locally. This PR adds a setting to allow modifying the factory used, while falling back to UnixBuild if nothing is set.

This was useful while working on https://github.com/python/buildmaster-config/pull/601