### PR TITLE
Skip having a PR builder for nondebug WASI

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -325,7 +325,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         # 10pm UTC and 2am UTC, it will be delayed to 2am UTC.
         if worker_name == "diegorusso-aarch64-bigmem":
             builder.canStartBuild = no_builds_between("22:00", "2:00")
-        
+
         # This worker restarts every day at 9am UTC to work around issues stemming from
         # failing bigmem tests trashing disk space and fragmenting RAM. Builds scheduled
         # between 07:20am - 9:20am UTC will be delayed to 9:20am UTC.
@@ -366,10 +366,6 @@ all_pull_request_builders = []
 
 for name, worker_name, buildfactory, stability, tier in BUILDERS:
     buildername = f"{name} PR"
-    all_pull_request_builders.append(buildername)
-    if stability == STABLE:
-        stable_pull_request_builders.append(buildername)
-
     source = GitHub(repourl=git_url, **GIT_KWDS)
 
     f = buildfactory(
@@ -385,6 +381,14 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     tags = ["PullRequest", stability, *getattr(f, "tags", [])]
     if tier:
         tags.append(tier)
+
+    # The nondebug WASI builder does not work across all Python versions
+    # due to some file locations being different and `wasi.py` not being
+    # available.
+    # As such, it's just easier to skip the builder entirely for PRs.
+    # This can be removed once we are only supporting >= 3.13.
+    if "wasm" in tags and "nondebug" in tags:
+        continue
 
     builder = util.BuilderConfig(
         name=buildername,
@@ -402,6 +406,9 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
         builder.canStartBuild = no_builds_between("22:00", "2:00")
 
     c["builders"].append(builder)
+    all_pull_request_builders.append(buildername)
+    if stability == STABLE:
+        stable_pull_request_builders.append(buildername)
 
 c["schedulers"].append(
     GitHubPrScheduler(


### PR DESCRIPTION
A confluence of file locations moving between versions and `wasi.py` only being available starting in Python 3.13 is causing this. It's just easier to rely on the debug PR builder.