### PR TITLE
Take two at fixing WASI config.site usage

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -893,6 +893,7 @@ class Wasm32WasiCrossBuild(UnixCrossBuild):
                 warnOnFailure=True,
             )
         )
+        self.compile_environ = super().compile_environ.copy()
         self.compile_environ.update(
             CONFIG_SITE=util.Interpolate("%(prop:config_site)s")
         )

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -893,7 +893,9 @@ class Wasm32WasiCrossBuild(UnixCrossBuild):
                 warnOnFailure=True,
             )
         )
-        self.host_configure_cmd.append(util.Interpolate("CONFIG_SITE=%(prop:config_site)s"))
+        self.compile_environ.update(
+            CONFIG_SITE=util.Interpolate("%(prop:config_site)s")
+        )
         self.addStep(
             ShellCommand(
                 name="Touch srcdir Modules/Setup.local",

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -895,7 +895,7 @@ class Wasm32WasiCrossBuild(UnixCrossBuild):
         )
         self.compile_environ = super().compile_environ.copy()
         self.compile_environ.update(
-            CONFIG_SITE=util.Interpolate("%(prop:config_site)s")
+            CONFIG_SITE=util.Interpolate("../../%(prop:config_site)s")
         )
         self.addStep(
             ShellCommand(


### PR DESCRIPTION
This is both closer to what was done originally, and should be much more robust :)

My local test is still running, will move to ready when it is done.

The `self.compile_environ` is used during the configure here: https://github.com/python/buildmaster-config/blob/676f2e3c89117cf75dcd61ccd8c1049afb9b5512/master/custom/factories.py#L797-L804