### PR TITLE
Fix the dashboard

### DIFF
--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -303,7 +303,10 @@ class Branch(_BranchTierBase):
         problems = []
         for builder in self._root.builders:
             if builder.branch == self:
-                problems.extend(builder.problems)
+                if builder.problems:
+                    problems.extend(builder.problems)
+                else:
+                    problems.append(NoProblem(builder))
         return problems
 
     @cached_property
@@ -682,8 +685,11 @@ class BuilderDisconnected(Problem):
         return severity, description
 
 
+@dataclass
 class NoProblem(Problem):
     """Dummy problem"""
+    builder: Builder | None = None
+
     name = "Releasable"
 
     description = "No problem detected"

--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -688,7 +688,7 @@ class BuilderDisconnected(Problem):
 @dataclass
 class NoProblem(Problem):
     """Dummy problem"""
-    builder: Builder | None = None
+    builder: 'Builder | None' = None
 
     name = "Releasable"
 

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -206,7 +206,10 @@
                                         </div>
                                     {% endif %}
                                     <div class="build-dots">
-                                        {% for build in builder.builds[:70] %}
+                                        {% for build in builder.builds %}
+                                            {% if loop.index0 == (50 if builder.problems else 3) %}
+                                                ⋯ {% break %}
+                                            {% endif %}
                                             {{ build_dot(build) }}
                                         {% endfor %}
                                     </div>


### PR DESCRIPTION
The code for finding failing streaks has a bug where it can ignore a failure. Fix that.

Also, show “green” builders in the report, so that if a similar issue comes up in the future, it can be found more easily.