### PR TITLE
Skip old branches for FIPS builders

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -91,6 +91,8 @@ def get_workers(settings):
             name="cstratak-RHEL8-fips-x86_64",
             tags=['linux', 'unix', 'rhel', 'amd64', 'x86-64', 'fips'],
             parallel_tests=6,
+            # Only 3.12+ for FIPS builder
+            not_branches=["3.9", "3.10", "3.11"],
         ),
         cpw(
             name="cstratak-CentOS9-x86_64",
@@ -101,6 +103,8 @@ def get_workers(settings):
             name="cstratak-CentOS9-fips-x86_64",
             tags=['linux', 'unix', 'rhel', 'amd64', 'x86-64', 'fips'],
             parallel_tests=6,
+            # Only 3.12+ for FIPS builder
+            not_branches=["3.9", "3.10", "3.11"],
         ),
         cpw(
             name="cstratak-fedora-rawhide-ppc64le",

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -295,10 +295,6 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         if 'nogil' in tags and branchname in {"3.9", "3.10", "3.11", "3.12"}:
             continue
 
-        # Only 3.12+ for FIPS builders
-        if 'fips' in tags and branchname in {"3.9", "3.10", "3.11"}:
-            continue
-
         if 'refleak' in tags:
             refleakbuildernames.append(buildername)
         else:


### PR DESCRIPTION
This should fix the ineffective change made in https://github.com/python/buildmaster-config/pull/558 (9f84063853c9f5cc43a649e9f54a5b1afdbb7e5e)

The `tags` in master.cfg are *factory* tags, not *worker* tags. Skip old branches using `not_branches` instead.

Note that these are unstable and failing, except “Only Blake2” which is stable, and only fails on 3.11.
(The 3.9 3.10 builders are stable and passing, but not very interesting at this point.)