### PR TITLE
Add builder configuration for emscripten.

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -48,6 +48,7 @@ from custom.factories import (
     Wasm32WasiPreview1DebugBuild,
     IOSARM64SimulatorBuild,
     AndroidBuild,
+    EmscriptenBuild,
     ValgrindBuild,
 )
 
@@ -190,6 +191,9 @@ STABLE_BUILDERS_TIER_3 = [
     # Android
     ("aarch64 Android", "mhsmith-android-aarch64", AndroidBuild),
     ("AMD64 Android", "mhsmith-android-x86_64", AndroidBuild),
+
+    # Emscripten
+    ("WASM Emscripten", "rkm-emscripten", EmscriptenBuild),
 ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -191,9 +191,6 @@ STABLE_BUILDERS_TIER_3 = [
     # Android
     ("aarch64 Android", "mhsmith-android-aarch64", AndroidBuild),
     ("AMD64 Android", "mhsmith-android-x86_64", AndroidBuild),
-
-    # Emscripten
-    ("WASM Emscripten", "rkm-emscripten", EmscriptenBuild),
 ]
 
 
@@ -303,6 +300,9 @@ UNSTABLE_BUILDERS_TIER_3 = [
     # FreBSD x86-64 clang
     # FreeBSD 15 is CURRENT: development branch (at 2023-10-17)
     ("AMD64 FreeBSD15", "opsec-fbsd15", UnixBuild),
+
+    # Emscripten
+    ("WASM Emscripten", "rkm-emscripten", EmscriptenBuild),
 ]
 
 


### PR DESCRIPTION
Adds the builder configuration mistakenly omitted by #611.