### PR TITLE
Mark cstratak-*-aarch64 & itamaro-macos-intel-aws builders as unstable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -95,8 +95,6 @@ STABLE_BUILDERS_TIER_1 = [
 
     # macOS x86-64 clang
     ("x86-64 macOS", "billenstein-macos", UnixBuild),
-    ("x86-64 MacOS Intel NoGIL", "itamaro-macos-intel-aws", UnixNoGilBuild),
-    ("x86-64 MacOS Intel ASAN NoGIL", "itamaro-macos-intel-aws", MacOSAsanNoGilBuild),
 ]
 
 
@@ -226,6 +224,11 @@ UNSTABLE_BUILDERS_TIER_1 = [
 
     # Windows MSVC
     ("AMD64 Windows PGO", "bolen-windows10", Windows64PGOBuild),
+
+    # macOS x86-64 clang
+    # (marked unstable for a hardware failure)
+    ("x86-64 MacOS Intel NoGIL", "itamaro-macos-intel-aws", UnixNoGilBuild),
+    ("x86-64 MacOS Intel ASAN NoGIL", "itamaro-macos-intel-aws", MacOSAsanNoGilBuild),
 ]
 
 

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -118,20 +118,6 @@ STABLE_BUILDERS_TIER_2 = [
     ("PPC64LE RHEL8 LTO", "cstratak-RHEL8-ppc64le", LTONonDebugUnixBuild),
     ("PPC64LE RHEL8 LTO + PGO", "cstratak-RHEL8-ppc64le", LTOPGONonDebugBuild),
 
-    # Fedora Linux aarch64 GCC/clang
-    ("aarch64 Fedora Stable", "cstratak-fedora-stable-aarch64", FedoraStableBuild),
-    ("aarch64 Fedora Stable Refleaks", "cstratak-fedora-stable-aarch64", UnixRefleakBuild),
-    ("aarch64 Fedora Stable Clang", "cstratak-fedora-stable-aarch64", ClangUnixBuild),
-    ("aarch64 Fedora Stable Clang Installed", "cstratak-fedora-stable-aarch64", ClangUnixInstalledBuild),
-    ("aarch64 Fedora Stable LTO", "cstratak-fedora-stable-aarch64", LTONonDebugUnixBuild),
-    ("aarch64 Fedora Stable LTO + PGO", "cstratak-fedora-stable-aarch64", LTOPGONonDebugBuild),
-
-    # RHEL8 aarch64 GCC
-    ("aarch64 RHEL8", "cstratak-RHEL8-aarch64", RHEL8Build),
-    ("aarch64 RHEL8 Refleaks", "cstratak-RHEL8-aarch64", UnixRefleakBuild),
-    ("aarch64 RHEL8 LTO", "cstratak-RHEL8-aarch64", LTONonDebugUnixBuild),
-    ("aarch64 RHEL8 LTO + PGO", "cstratak-RHEL8-aarch64", LTOPGONonDebugBuild),
-
     ("aarch64 Ubuntu 22.04 BigMem", "diegorusso-aarch64-bigmem", UnixBigmemBuild),
 
     # macOS aarch64 clang
@@ -272,6 +258,22 @@ UNSTABLE_BUILDERS_TIER_2 = [
     ("aarch64 Fedora Rawhide Clang Installed", "cstratak-fedora-rawhide-aarch64", ClangUnixInstalledBuild),
     ("aarch64 Fedora Rawhide LTO", "cstratak-fedora-rawhide-aarch64", LTONonDebugUnixBuild),
     ("aarch64 Fedora Rawhide LTO + PGO", "cstratak-fedora-rawhide-aarch64", LTOPGONonDebugBuild),
+
+    # Fedora Linux aarch64 GCC/clang
+    # (marked unstable for a hardware migration)
+    ("aarch64 Fedora Stable", "cstratak-fedora-stable-aarch64", FedoraStableBuild),
+    ("aarch64 Fedora Stable Refleaks", "cstratak-fedora-stable-aarch64", UnixRefleakBuild),
+    ("aarch64 Fedora Stable Clang", "cstratak-fedora-stable-aarch64", ClangUnixBuild),
+    ("aarch64 Fedora Stable Clang Installed", "cstratak-fedora-stable-aarch64", ClangUnixInstalledBuild),
+    ("aarch64 Fedora Stable LTO", "cstratak-fedora-stable-aarch64", LTONonDebugUnixBuild),
+    ("aarch64 Fedora Stable LTO + PGO", "cstratak-fedora-stable-aarch64", LTOPGONonDebugBuild),
+
+    # RHEL8 aarch64 GCC
+    # (marked unstable for a hardware migration)
+    ("aarch64 RHEL8", "cstratak-RHEL8-aarch64", RHEL8Build),
+    ("aarch64 RHEL8 Refleaks", "cstratak-RHEL8-aarch64", UnixRefleakBuild),
+    ("aarch64 RHEL8 LTO", "cstratak-RHEL8-aarch64", LTONonDebugUnixBuild),
+    ("aarch64 RHEL8 LTO + PGO", "cstratak-RHEL8-aarch64", LTOPGONonDebugBuild),
 
     # CentOS Stream 9 Linux aarch64 GCC
     ("aarch64 CentOS9 Refleaks", "cstratak-CentOS9-aarch64", UnixRefleakBuild),


### PR DESCRIPTION
Fedora/RHEL aarch64 are down. I reached out to @stratakis, who said the server was now decommissioned, work is underway to add a new server from ARM, but it might take a while.

I think it's best to mark the builders as unstable, rather than remove them. That way we shouldn't need a PR before bringing them online, but only after they're up and green for a few days.

cc @vstinner @gpshead: until the new server is racked, there's only `diegorusso-aarch64-bigmem` for `aarch64-unknown-linux-gnu`.