### PR TITLE
Reduce concurrency on iOS simulators.

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -307,7 +307,7 @@ def get_workers(settings):
             name="rkm-arm64-ios-simulator",
             tags=['iOS'],
             not_branches=['3.9', '3.10', '3.11', '3.12'],
-            parallel_builders=4,
+            parallel_builders=1,  # All builds use the same simulator
         ),
         cpw(
             name="rkm-emscripten",


### PR DESCRIPTION
python/cpython#138018 modified the way that simulators are used by the iOS testbed runner; as a result, they are all now *sharing* simulators, rather than using clones. 

As a temporary fix, this reduces the concurrency on the buildbot so that builds won't collide. I have some ideas for a better long-term fix, but for now, this should fix the immediate problems we're seeing.