### PR TITLE
Don't have a WASI nondebug PR builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -321,7 +321,7 @@ for branch_num, (git_url, branchname, git_branch) in enumerate(git_branches):
         # 10pm UTC and 2am UTC, it will be delayed to 2am UTC.
         if worker_name == "diegorusso-aarch64-bigmem":
             builder.canStartBuild = no_builds_between("22:00", "2:00")
-        
+
         # This worker restarts every day at 9am UTC to work around issues stemming from
         # failing bigmem tests trashing disk space and fragmenting RAM. Builds scheduled
         # between 07:20am - 9:20am UTC will be delayed to 9:20am UTC.
@@ -362,9 +362,6 @@ all_pull_request_builders = []
 
 for name, worker_name, buildfactory, stability, tier in BUILDERS:
     buildername = f"{name} PR"
-    all_pull_request_builders.append(buildername)
-    if stability == STABLE:
-        stable_pull_request_builders.append(buildername)
 
     source = GitHub(repourl=git_url, **GIT_KWDS)
 
@@ -381,6 +378,16 @@ for name, worker_name, buildfactory, stability, tier in BUILDERS:
     tags = ["PullRequest", stability, *getattr(f, "tags", [])]
     if tier:
         tags.append(tier)
+
+    # Don't use the WASI buildbot meant for 3.11 and 3.12 on PRs;
+    # it's tier 3 only and getting it to work on PRs against `main`
+    # is too much work.
+    if "wasi" in tags and "nondebug" in tags:
+        continue
+
+    all_pull_request_builders.append(buildername)
+    if stability == STABLE:
+        stable_pull_request_builders.append(buildername)
 
     builder = util.BuilderConfig(
         name=buildername,


### PR DESCRIPTION
It's primarily for testing 3.11 and 3.12 which is tier 3 only for WASI. Trying to keep it working is a perpetual issue and prevents https://github.com/python/cpython/pull/138203 from landing.