### PR TITLE
Correct launch of Emscripten pyrepl smoke test.

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1396,7 +1396,7 @@ class EmscriptenBuild(BaseBuild):
             Test(
                 name="PyRepl in Chrome smoke test",
                 command=[
-                    "run_test.sh",
+                    "./run_test.sh",
                 ],
                 env=compile_environ,
                 timeout=step_timeout(self.test_timeout),


### PR DESCRIPTION
The Emscripten smoke test added by #616 is [crashing on launch](https://buildbot.python.org/#/builders/1808/builds/171).

I'm not 100% clear on why - but it looks like the combination of `workdir` and a command line of `run_tests.sh` is being interpreted as `/bin/run_tests.sh`. I'm hoping making the path slightly more explicit will resolve this.