### PR TITLE
Correct the working directory for Emscripten PyRepl tests

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1396,11 +1396,11 @@ class EmscriptenBuild(BaseBuild):
             Test(
                 name="PyRepl in Chrome smoke test",
                 command=[
-                    "run_test.sh",
+                    "./run_test.sh",
                 ],
                 env=compile_environ,
                 timeout=step_timeout(self.test_timeout),
-                workdir="build/Tools/wasm/emscripten/browser_test",
+                workdir="Tools/wasm/emscripten/browser_test",
             ),
             Clean(
                 name="Clean the builds",

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1396,11 +1396,11 @@ class EmscriptenBuild(BaseBuild):
             Test(
                 name="PyRepl in Chrome smoke test",
                 command=[
-                    "./run_test.sh",
+                    "run_test.sh",
                 ],
                 env=compile_environ,
                 timeout=step_timeout(self.test_timeout),
-                workdir="Tools/wasm/emscripten/browser_test",
+                workdir="build/Tools/wasm/emscripten/browser_test",
             ),
             Clean(
                 name="Clean the builds",

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1396,11 +1396,10 @@ class EmscriptenBuild(BaseBuild):
             Test(
                 name="PyRepl in Chrome smoke test",
                 command=[
-                    "./run_test.sh",
+                    "Tools/wasm/emscripten/browser_test/run_test.sh",
                 ],
                 env=compile_environ,
                 timeout=step_timeout(self.test_timeout),
-                workdir="Tools/wasm/emscripten/browser_test",
             ),
             Clean(
                 name="Clean the builds",


### PR DESCRIPTION
An update to #624 - it looks like the issue was the working directory not including the OOT `build` prefix.