### PR TITLE
Use `--slow-ci` on Android

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1245,13 +1245,9 @@ class AndroidBuild(BaseBuild):
             Test(
                 command=[
                     android_py, "test", "--managed", "maxVersion", "-v", "--",
-                    "-uall", "--single-process", "--rerun", "-W",
+                    "--slow-ci", "--single-process", "--no-randomize",
                 ],
                 timeout=step_timeout(self.test_timeout),
-            ),
-            ShellCommand(
-                name="Clean",
-                command=[android_py, "clean"],
             ),
         ])
 


### PR DESCRIPTION
https://github.com/python/cpython/pull/138649 switched the Android tests on GitHub Actions to use `--fast-ci`. This PR makes the corresponding change on the buildbots.

It also removes the post-build clean step. This is unnecessary since the tree will be cleaned at the start of the next build, and makes it more difficult to diagnose failures.