### PR TITLE
Replace diegorusso AArch64 worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -114,8 +114,6 @@ STABLE_BUILDERS_TIER_2 = [
     ("PPC64LE RHEL8 LTO", "cstratak-RHEL8-ppc64le", LTONonDebugUnixBuild),
     ("PPC64LE RHEL8 LTO + PGO", "cstratak-RHEL8-ppc64le", LTOPGONonDebugBuild),
 
-    ("aarch64 Ubuntu 22.04 BigMem", "diegorusso-aarch64-bigmem", UnixBigmemBuild),
-
     # macOS aarch64 clang
     ("ARM64 macOS", "pablogsal-macos-m1", MacOSArmWithBrewBuild),
     ("ARM64 MacOS M1 NoGIL", "itamaro-macos-arm64-aws", MacOSArmWithBrewNoGilBuild),
@@ -206,6 +204,10 @@ STABLE_BUILDERS_NO_TIER = [
 
 # -- Unstable Tier-1 builders -------------------------------------------
 UNSTABLE_BUILDERS_TIER_1 = [
+
+    # Ubuntu Linux AArch64
+    ("aarch64 Ubuntu 24.04 BigMem", "diegorusso-aarch64-bigmem", UnixBigmemBuild),
+
     # Linux x86-64 GCC
     # Fedora Rawhide is unstable
     ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", FedoraRawhideBuild),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -273,10 +273,10 @@ class UnixBuildWithoutDocStrings(UnixBuild):
 class UnixBigmemBuild(UnixBuild):
     buildersuffix = ".bigmem"
     testFlags = [
-        "-M60g", "-j4", "-uall,extralargefile",
+        "-M60g", "-j8", "-uall,extralargefile",
         "--prioritize=test_bigmem,test_lzma,test_bz2,test_re,test_array"
     ]
-    test_timeout = TEST_TIMEOUT * 4
+    test_timeout = TEST_TIMEOUT * 5
     factory_tags = ["bigmem"]
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -152,8 +152,8 @@ def get_workers(settings):
         cpw(
             name="diegorusso-aarch64-bigmem",
             tags=['linux', 'unix', 'ubuntu', 'arm', 'arm64', 'aarch64', 'bigmem'],
-            not_branches=['3.9', '3.10', '3.11', '3.12', '3.13'],
-            parallel_tests=4,
+            not_branches=['3.9', '3.10', '3.11', '3.12', '3.13', '3.14'],
+            parallel_tests=8,
         ),
         cpw(
             name="cstratak-fedora-rawhide-s390x",


### PR DESCRIPTION
The old machine has been decommisioned and replaced with a new more powerful one.
This is an AmpereOne with 192 cores and 500GB of memory.