### PR TITLE
Move `ARM64 Raspbian Debug` builder to stable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -160,6 +160,7 @@ STABLE_BUILDERS_TIER_3 = [
     # Linux armv7l (32-bit) GCC
     ("ARM Raspbian", "gps-raspbian", SlowNonDebugUnixBuild),
     ("ARM64 Raspbian", "stan-raspbian", SlowNonDebugUnixBuild),
+    ("ARM64 Raspbian Debug", "savannah-raspbian", SlowDebugUnixBuild),
 
     # FreBSD x86-64 clang
     ("AMD64 FreeBSD", "ware-freebsd", UnixBuild),
@@ -312,9 +313,6 @@ UNSTABLE_BUILDERS_TIER_3 = [
 
     # Emscripten
     ("WASM Emscripten", "rkm-emscripten", EmscriptenBuild),
-
-    # Linux aarch64 GCC/Clang
-    ("ARM64 Raspbian Debug", "savannah-raspbian", SlowDebugUnixBuild),
 ]
 
 


### PR DESCRIPTION
[All green over a few builds of each branch!](https://buildbot.python.org/#/workers/120)

In [one 3.14 build](https://buildbot.python.org/#/builders/1824/builds/9) some warnings were raised in pyrepl tests, though I recognise seeing this occasionally on the other ARM64 Raspbian builder (e.g. this [run](https://buildbot.python.org/#/builders/1764/builds/440)).