### PR TITLE
Update Android test arguments

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1249,8 +1249,7 @@ class AndroidBuild(BaseBuild):
             ),
             Test(
                 command=[
-                    android_py, "test", "--managed", "maxVersion", "-v", "--",
-                    "--slow-ci", "--single-process", "--no-randomize",
+                    android_py, "test", "--managed", "maxVersion", "-v", "--slow-ci"
                 ],
                 timeout=step_timeout(self.test_timeout),
             ),


### PR DESCRIPTION
In https://github.com/python/cpython/pull/138805 we added a `--slow-ci` option to the Android test script, which not only passes   `"--slow-ci", "--single-process", "--no-randomize"`, but also sets the correct options for the Python interpreter. This should change the buildbot status from [orange back to green](https://buildbot.python.org/#/workers/109).