### PR TITLE
Update release-cycle.json URL to use PEPs API

### DIFF
--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -29,7 +29,7 @@ MAX_CHANGES = 50
 # get a cache hit.
 CACHE_DURATION = 6 * 60
 
-BRANCHES_URL = "https://raw.githubusercontent.com/python/devguide/main/include/release-cycle.json"
+BRANCHES_URL = "https://peps.python.org/api/release-cycle.json"
 
 
 def _gimme_error(func):


### PR DESCRIPTION
This file is now generated and published from the PEPs repo (https://github.com/python/peps/pull/4331) and will be removed from the devguide soon (https://github.com/python/devguide/pull/1685).