### PR TITLE
Hard-code the location for the WASI SDK for the non-debug WASI workers

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -889,7 +889,7 @@ class UnixCrossBuild(UnixBuild):
 class Wasm32WasiCrossBuild(UnixCrossBuild):
     """wasm32-wasi builder
 
-    * WASI SDK >= 16 must be installed to default path /opt/wasi-sdk
+    * WASI SDK 21 must be installed at /opt/wasi-sdk-21.0
     * wasmtime must be installed and on PATH
     """
 
@@ -924,6 +924,7 @@ class Wasm32WasiCrossBuild(UnixCrossBuild):
                 haltOnFailure=True,
             )
         )
+        self.compile_environ["WASI_SDK_PATH"] = "/opt/wasi-sdk-21.0"
         super().setup(parallel, branch, test_with_PTY=test_with_PTY, **kwargs)
 
 


### PR DESCRIPTION
Only run on Python 3.11 and 3.12 with WASI SDK 21. Hard-coding allows for symlinking `/opt/wasi-sdk` to WASI SDK 24 for Python 3.13. For Python 3.14 and later this is not a concern as `Tools/wasm/wasi` find the appropriate WASI SDK automatically in `/opt`.

How this gets used during `./configure` can be seen at https://github.com/python/cpython/blob/0e4cd897811651d896c5be9beec803b506131c7c/Tools/wasm/wasi-env#L32 .