### PR TITLE
Remove ARM Raspbian ASAN builder and reduce parallelism

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -194,7 +194,6 @@ STABLE_BUILDERS_NO_TIER = [
     ("AMD64 Arch Linux Asan Debug", "pablogsal-arch-x86_64", UnixAsanDebugBuild),
     ("AMD64 Arch Linux TraceRefs", "pablogsal-arch-x86_64", UnixTraceRefsBuild),
     ("AMD64 Arch Linux Perf", "pablogsal-arch-x86_64", UnixPerfBuild),
-    ("ARM Raspbian Linux Asan", "pablogsal-rasp", UnixAsanBuild),
     # UBSAN with -fno-sanitize=function, without which we currently fail (as
     #  tracked in gh-111178). The full "AMD64 Arch Linux Usan" is unstable, below
     ("AMD64 Arch Linux Usan Function", "pablogsal-arch-x86_64", ClangUbsanFunctionLinuxBuild),

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -222,7 +222,7 @@ def get_workers(settings):
         cpw(
             name="pablogsal-rasp",
             tags=['linux', 'unix', 'raspbian', 'debian', 'arm'],
-            parallel_tests=2,
+            parallel_tests=1,  # Reduced from 2: ASAN builds use 2-10x more memory
             # Problematic ISP causes issues connecting to testpython.net
             exclude_test_resources=['urlfetch', 'network'],
         ),


### PR DESCRIPTION
Remove ARM Raspbian ASAN builder  from the stable builders list
because ASAN builds require significantly more memory than regular
builds, making them impractical on the resource-constrained Raspberry
Pi hardware.

The parallel test count for the pablogsal-rasp worker was reduced from
2 to 1 to account for this higher memory usage. ASAN instrumentation
typically increases memory consumption by 2-10x, and running multiple
test processes in parallel on a Raspberry Pi can exhaust available
memory and cause build failures.
