### PR TITLE
Update buildbot to use XCframework build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib/
 venv/
 worker/
 settings.yaml
+.vscode/

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1045,200 +1045,216 @@ class _IOSSimulatorBuild(UnixBuild):
 
         super().__init__(source, **kwargs)
 
-    def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
-        if branch == "3.13":
-            out_of_tree_dir = "build_oot"
-            oot_dir_path = os.path.join("build", out_of_tree_dir)
-            oot_build_path = os.path.join(oot_dir_path, "build")
-            oot_host_path = os.path.join(oot_dir_path, "host")
+    def historical_setup(self, parallel, test_with_PTY=False):
+        out_of_tree_dir = "build_oot"
+        oot_dir_path = os.path.join("build", out_of_tree_dir)
+        oot_build_path = os.path.join(oot_dir_path, "build")
+        oot_host_path = os.path.join(oot_dir_path, "host")
 
-            # Create out of tree directory for "build", the platform we are
-            # currently running on
-            self.addStep(
-                ShellCommand(
-                    name="mkdir build out-of-tree directory",
-                    description="Create build out-of-tree directory",
-                    command=["mkdir", "-p", oot_build_path],
-                    warnOnFailure=True,
-                )
+        # Create out of tree directory for "build", the platform we are
+        # currently running on
+        self.addStep(
+            ShellCommand(
+                name="mkdir build out-of-tree directory",
+                description="Create build out-of-tree directory",
+                command=["mkdir", "-p", oot_build_path],
+                warnOnFailure=True,
             )
-            # Create directory for "host", the platform we want to compile *for*
-            self.addStep(
-                ShellCommand(
-                    name="mkdir host out-of-tree directory",
-                    description="Create host out-of-tree directory",
-                    command=["mkdir", "-p", oot_host_path],
-                    warnOnFailure=True,
-                )
+        )
+        # Create directory for "host", the platform we want to compile *for*
+        self.addStep(
+            ShellCommand(
+                name="mkdir host out-of-tree directory",
+                description="Create host out-of-tree directory",
+                command=["mkdir", "-p", oot_host_path],
+                warnOnFailure=True,
             )
+        )
 
-            # First, we build the "build" Python, which we need to cross compile
-            # the "host" Python
-            self.addStep(
-                Configure(
-                    name="Configure build Python",
-                    command=["../../configure"],
-                    workdir=oot_build_path,
-                )
+        # First, we build the "build" Python, which we need to cross compile
+        # the "host" Python
+        self.addStep(
+            Configure(
+                name="Configure build Python",
+                command=["../../configure"],
+                workdir=oot_build_path,
             )
-            if parallel:
-                compile = ["make", parallel]
-            else:
-                compile = ["make"]
-
-            self.addStep(
-                Compile(
-                    name="Compile build Python", command=compile, workdir=oot_build_path
-                )
-            )
-
-            # Ensure the host path is isolated from Homebrew et al, but includes
-            # the host helper binaries. Also add the configuration paths for
-            # library dependencies.
-            support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
-            compile_environ = dict(self.compile_environ)
-            compile_environ.update(
-                {
-                    "PATH": os.pathsep.join(
-                        [
-                            # This is intentionally a relative path. Buildbot doesn't expose
-                            # the absolute working directory where the build is running as
-                            # something that can be expanded into an environment variable.
-                            "../../iOS/Resources/bin",
-                            "/usr/bin",
-                            "/bin",
-                            "/usr/sbin",
-                            "/sbin",
-                            "/Library/Apple/usr/bin",
-                        ]
-                    ),
-                    "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
-                    "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
-                    "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
-                    "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
-                    "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
-                    "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
-                }
-            )
-
-            # Now that we have a "build" architecture Python, we can use that
-            # to build a "host" (also known as the target we are cross compiling)
-            # Take a copy so that the class-level definition isn't tainted
-            configure_cmd = list(self.host_configure_cmd)
-            configure_cmd += self.configureFlags
-            configure_cmd += self.extra_configure_flags
-            configure_cmd += [
-                f"--with-openssl={support_path}/openssl",
-                f"--build={self.arch}-apple-darwin",
-                f"--host={self.host}",
-                "--with-build-python=../build/python.exe",
-                "--enable-framework",
-            ]
-
-            self.addStep(
-                Configure(
-                    name="Configure host Python",
-                    command=configure_cmd,
-                    env=compile_environ,
-                    workdir=oot_host_path,
-                )
-            )
-
-            if parallel:
-                compile = ["make", parallel, self.makeTarget]
-                install = ["make", parallel, "install"]
-            else:
-                compile = ["make", self.makeTarget]
-                install = ["make", "install"]
-
-            self.addStep(
-                Compile(
-                    name="Compile host Python",
-                    command=compile,
-                    env=compile_environ,
-                    workdir=oot_host_path,
-                )
-            )
-            self.addStep(
-                Compile(
-                    name="Install host Python",
-                    command=install,
-                    env=compile_environ,
-                    workdir=oot_host_path,
-                )
-            )
-            self.addStep(
-                Test(
-                    command=["make", "testios"],
-                    timeout=step_timeout(self.test_timeout),
-                    usePTY=test_with_PTY,
-                    env=self.test_environ,
-                    workdir=oot_host_path,
-                )
-            )
-
-            self.addStep(
-                Clean(
-                    name="Clean build Python",
-                    workdir=oot_build_path,
-                )
-            )
-            self.addStep(
-                Clean(
-                    name="Clean host Python",
-                    workdir=oot_host_path,
-                )
-            )
+        )
+        if parallel:
+            compile = ["make", parallel]
         else:
-            # Builds of Python 3.14+ can use the XCframework build script.
-            #
-            # The script moved to the Platforms folder in 3.15; the first command
-            # symlinks to the "new" location so that the 3.15+ build instructions
-            # will work as-is. This will fail on <= 3.13 PR branches.
-            build_environ = {
-                "CACHE_DIR": "/Users/buildbot/downloads",
-            }
+            compile = ["make"]
 
-            self.addSteps(
-                [
-                    ShellCommand(
-                        name="Set up compatibility symlink",
-                        command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
-                    ),
-                    Compile(
-                        name="Configure and compile build Python",
-                        command=["python3", "Platforms/Apple", "build", "iOS", "build"],
-                        env=build_environ,
-                    ),
-                    Compile(
-                        name="Configure and compile host Pythons",
-                        command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
-                        env=build_environ,
-                    ),
-                    Compile(
-                        name="Package XCframework",
-                        command=["python3", "Platforms/Apple", "package", "iOS"],
-                        env=build_environ,
-                    ),
-                    Test(
-                        name="Run test suite",
-                        command=[
-                            "python3",
-                            "Platforms/Apple",
-                            "test",
-                            "iOS",
-                            "--slow-ci",
-                        ],
-                        env=build_environ,
-                        timeout=step_timeout(self.test_timeout),
-                    ),
-                    Clean(
-                        name="Clean the builds",
-                        command=["python3", "Platforms/Apple", "clean", "iOS"],
-                        env=build_environ,
-                    ),
-                ]
+        self.addStep(
+            Compile(
+                name="Compile build Python", command=compile, workdir=oot_build_path
             )
+        )
+
+        # Ensure the host path is isolated from Homebrew et al, but includes
+        # the host helper binaries. Also add the configuration paths for
+        # library dependencies.
+        support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
+        compile_environ = dict(self.compile_environ)
+        compile_environ.update(
+            {
+                "PATH": os.pathsep.join(
+                    [
+                        # This is intentionally a relative path. Buildbot doesn't expose
+                        # the absolute working directory where the build is running as
+                        # something that can be expanded into an environment variable.
+                        "../../iOS/Resources/bin",
+                        "/usr/bin",
+                        "/bin",
+                        "/usr/sbin",
+                        "/sbin",
+                        "/Library/Apple/usr/bin",
+                    ]
+                ),
+                "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
+                "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
+                "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
+                "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
+                "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
+                "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
+            }
+        )
+
+        # Now that we have a "build" architecture Python, we can use that
+        # to build a "host" (also known as the target we are cross compiling)
+        # Take a copy so that the class-level definition isn't tainted
+        configure_cmd = list(self.host_configure_cmd)
+        configure_cmd += self.configureFlags
+        configure_cmd += self.extra_configure_flags
+        configure_cmd += [
+            f"--with-openssl={support_path}/openssl",
+            f"--build={self.arch}-apple-darwin",
+            f"--host={self.host}",
+            "--with-build-python=../build/python.exe",
+            "--enable-framework",
+        ]
+
+        self.addStep(
+            Configure(
+                name="Configure host Python",
+                command=configure_cmd,
+                env=compile_environ,
+                workdir=oot_host_path,
+            )
+        )
+
+        if parallel:
+            compile = ["make", parallel, self.makeTarget]
+            install = ["make", parallel, "install"]
+        else:
+            compile = ["make", self.makeTarget]
+            install = ["make", "install"]
+
+        self.addStep(
+            Compile(
+                name="Compile host Python",
+                command=compile,
+                env=compile_environ,
+                workdir=oot_host_path,
+            )
+        )
+        self.addStep(
+            Compile(
+                name="Install host Python",
+                command=install,
+                env=compile_environ,
+                workdir=oot_host_path,
+            )
+        )
+        self.addStep(
+            Test(
+                command=["make", "testios"],
+                timeout=step_timeout(self.test_timeout),
+                usePTY=test_with_PTY,
+                env=self.test_environ,
+                workdir=oot_host_path,
+            )
+        )
+
+        self.addStep(
+            Clean(
+                name="Clean build Python",
+                workdir=oot_build_path,
+            )
+        )
+        self.addStep(
+            Clean(
+                name="Clean host Python",
+                workdir=oot_host_path,
+            )
+        )
+
+    def current_setup(self):
+        build_environ = {
+            "CACHE_DIR": "/Users/buildbot/downloads",
+        }
+
+        self.addSteps(
+            [
+                # This symlink is needed to support Python 3.14 builds - it makes the
+                # top level Apple folder appear in the new Platforms/Apple location.
+                # It will fail on 3.13 PR branches because the top level Apple folder
+                # doesn't exist. This step can be removed when 3.14 is no longer
+                # supported.
+                ShellCommand(
+                    name="Set up compatibility symlink",
+                    command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
+                ),
+                # Build the full iOS XCframework, including a multi-arch simulator slice.
+                Compile(
+                    name="Configure and compile build Python",
+                    command=["python3", "Platforms/Apple", "build", "iOS", "build"],
+                    env=build_environ,
+                ),
+                Compile(
+                    name="Configure and compile host Pythons",
+                    command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
+                    env=build_environ,
+                ),
+                Compile(
+                    name="Package XCframework",
+                    command=["python3", "Platforms/Apple", "package", "iOS"],
+                    env=build_environ,
+                ),
+                Test(
+                    name="Run test suite",
+                    command=[
+                        "python3",
+                        "Platforms/Apple",
+                        "test",
+                        "iOS",
+                        "--slow-ci",
+                    ],
+                    env=build_environ,
+                    timeout=step_timeout(self.test_timeout),
+                ),
+                Clean(
+                    name="Clean the builds",
+                    command=["python3", "Platforms/Apple", "clean", "iOS"],
+                    env=build_environ,
+                ),
+            ]
+        )
+
+    def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
+        # Builds on Python 3.13 use a direct set of calls to make. Python 3.14
+        # introduced a simpler XCframework build script; Python 3.15 moved that
+        # script to the Platforms folder.
+        #
+        # The `Platforms/Apple` location can be used for 3.14 builds with a
+        # symlink, but 3.13 builds have to used the build process.
+        #
+        # The symlink approach will fail for Python 3.13 *PR* builds, because
+        # there's no way to identify the base branch for a PR.
+        if branch == "3.13":
+            self.historical_setup(parallel, test_with_PTY=test_with_PTY)
+        else:
+            self.current_setup()
 
 
 class IOSARM64SimulatorBuild(_IOSSimulatorBuild):

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1192,52 +1192,50 @@ class _IOSSimulatorBuild(UnixBuild):
             "CACHE_DIR": "/Users/buildbot/downloads",
         }
 
-        self.addSteps(
-            [
-                # This symlink is needed to support Python 3.14 builds - it makes the
-                # top level Apple folder appear in the new Platforms/Apple location.
-                # It will fail on 3.13 PR branches because the top level Apple folder
-                # doesn't exist. This step can be removed when 3.14 is no longer
-                # supported.
-                ShellCommand(
-                    name="Set up compatibility symlink",
-                    command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
-                ),
-                # Build the full iOS XCframework, including a multi-arch simulator slice.
-                Compile(
-                    name="Configure and compile build Python",
-                    command=["python3", "Platforms/Apple", "build", "iOS", "build"],
-                    env=build_environ,
-                ),
-                Compile(
-                    name="Configure and compile host Pythons",
-                    command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
-                    env=build_environ,
-                ),
-                Compile(
-                    name="Package XCframework",
-                    command=["python3", "Platforms/Apple", "package", "iOS"],
-                    env=build_environ,
-                ),
-                Test(
-                    name="Run test suite",
-                    command=[
-                        "python3",
-                        "Platforms/Apple",
-                        "test",
-                        "iOS",
-                        "--slow-ci",
-                    ],
-                    env=build_environ,
-                    timeout=step_timeout(self.test_timeout),
-                ),
-                Clean(
-                    name="Clean the builds",
-                    command=["python3", "Platforms/Apple", "clean", "iOS"],
-                    env=build_environ,
-                ),
-            ]
-        )
+        self.addSteps([
+            # This symlink is needed to support Python 3.14 builds - it makes the
+            # top level Apple folder appear in the new Platforms/Apple location.
+            # It will fail on 3.13 PR branches because the top level Apple folder
+            # doesn't exist. This step can be removed when 3.14 is no longer
+            # supported.
+            ShellCommand(
+                name="Set up compatibility symlink",
+                command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
+            ),
+            # Build the full iOS XCframework, including a multi-arch simulator slice.
+            Compile(
+                name="Configure and compile build Python",
+                command=["python3", "Platforms/Apple", "build", "iOS", "build"],
+                env=build_environ,
+            ),
+            Compile(
+                name="Configure and compile host Pythons",
+                command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
+                env=build_environ,
+            ),
+            Compile(
+                name="Package XCframework",
+                command=["python3", "Platforms/Apple", "package", "iOS"],
+                env=build_environ,
+            ),
+            Test(
+                name="Run test suite",
+                command=[
+                    "python3",
+                    "Platforms/Apple",
+                    "test",
+                    "iOS",
+                    "--slow-ci",
+                ],
+                env=build_environ,
+                timeout=step_timeout(self.test_timeout),
+            ),
+            Clean(
+                name="Clean the builds",
+                command=["python3", "Platforms/Apple", "clean", "iOS"],
+                env=build_environ,
+            ),
+        ])
 
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
         # Builds on Python 3.13 use a direct set of calls to make. Python 3.14

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1045,7 +1045,7 @@ class _IOSSimulatorBuild(UnixBuild):
 
         super().__init__(source, **kwargs)
 
-    def historical_setup(self, parallel, test_with_PTY=False):
+    def py313_setup(self, parallel, branch, test_with_PTY=False, **kwargs):
         out_of_tree_dir = "build_oot"
         oot_dir_path = os.path.join("build", out_of_tree_dir)
         oot_build_path = os.path.join(oot_dir_path, "build")
@@ -1087,7 +1087,9 @@ class _IOSSimulatorBuild(UnixBuild):
 
         self.addStep(
             Compile(
-                name="Compile build Python", command=compile, workdir=oot_build_path
+                name="Compile build Python",
+                command=compile,
+                workdir=oot_build_path,
             )
         )
 
@@ -1096,29 +1098,25 @@ class _IOSSimulatorBuild(UnixBuild):
         # library dependencies.
         support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
         compile_environ = dict(self.compile_environ)
-        compile_environ.update(
-            {
-                "PATH": os.pathsep.join(
-                    [
-                        # This is intentionally a relative path. Buildbot doesn't expose
-                        # the absolute working directory where the build is running as
-                        # something that can be expanded into an environment variable.
-                        "../../iOS/Resources/bin",
-                        "/usr/bin",
-                        "/bin",
-                        "/usr/sbin",
-                        "/sbin",
-                        "/Library/Apple/usr/bin",
-                    ]
-                ),
-                "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
-                "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
-                "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
-                "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
-                "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
-                "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
-            }
-        )
+        compile_environ.update({
+            "PATH": os.pathsep.join([
+                # This is intentionally a relative path. Buildbot doesn't expose
+                # the absolute working directory where the build is running as
+                # something that can be expanded into an environment variable.
+                "../../iOS/Resources/bin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+                "/Library/Apple/usr/bin",
+            ]),
+            "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
+            "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
+            "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
+            "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
+            "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
+            "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
+        })
 
         # Now that we have a "build" architecture Python, we can use that
         # to build a "host" (also known as the target we are cross compiling)
@@ -1189,7 +1187,7 @@ class _IOSSimulatorBuild(UnixBuild):
             )
         )
 
-    def current_setup(self):
+    def current_setup(self, parallel, branch, test_with_PTY=False, **kwargs):
         build_environ = {
             "CACHE_DIR": "/Users/buildbot/downloads",
         }
@@ -1252,9 +1250,9 @@ class _IOSSimulatorBuild(UnixBuild):
         # The symlink approach will fail for Python 3.13 *PR* builds, because
         # there's no way to identify the base branch for a PR.
         if branch == "3.13":
-            self.historical_setup(parallel, test_with_PTY=test_with_PTY)
+            self.py313_setup(parallel, branch, test_with_PTY=test_with_PTY, **kwargs)
         else:
-            self.current_setup()
+            self.current_setup(parallel, branch, test_with_PTY=test_with_PTY, **kwargs)
 
 
 class IOSARM64SimulatorBuild(_IOSSimulatorBuild):

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1046,7 +1046,7 @@ class _IOSSimulatorBuild(UnixBuild):
         super().__init__(source, **kwargs)
 
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
-        if branch in {"3.13", "3.14"}:
+        if branch == "3.13":
             out_of_tree_dir = "build_oot"
             oot_dir_path = os.path.join("build", out_of_tree_dir)
             oot_build_path = os.path.join(oot_dir_path, "build")
@@ -1189,35 +1189,53 @@ class _IOSSimulatorBuild(UnixBuild):
                     workdir=oot_host_path,
                 )
             )
-        else:  # Builds of Python 3.15+
+        else:
+            # Builds of Python 3.14+ can use the XCframework build script.
+            #
+            # The script moved to the Platforms folder in 3.15; the first command
+            # symlinks to the "new" location so that the 3.15+ build instructions
+            # will work as-is. This will fail on <= 3.13 PR branches.
+            build_environ = {
+                "CACHE_DIR": "/Users/buildbot/downloads",
+            }
+
             self.addSteps(
                 [
+                    ShellCommand(
+                        name="Set up compatibility symlink (will fail on <= 3.13 branches)",
+                        command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
+                    ),
                     Compile(
                         name="Configure and compile build Python",
                         command=["python3", "Platforms/Apple", "build", "iOS", "build"],
+                        env=build_environ,
                     ),
                     Compile(
                         name="Configure and compile host Pythons",
                         command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
+                        env=build_environ,
                     ),
                     Compile(
                         name="Package XCframework",
                         command=["python3", "Platforms/Apple", "package", "iOS"],
+                        env=build_environ,
                     ),
                     Test(
                         name="Run test suite",
                         command=[
                             "python3",
                             "Platforms/Apple",
-                            "iOS",
                             "test",
+                            "iOS",
                             "--slow-ci",
                         ],
+                        env=build_environ,
                         timeout=step_timeout(self.test_timeout),
                     ),
                     Clean(
                         name="Clean the builds",
                         command=["python3", "Platforms/Apple", "clean", "iOS"],
+                        env=build_environ,
                     ),
                 ]
             )

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1032,6 +1032,7 @@ class _IOSSimulatorBuild(UnixBuild):
        build)
      * It invokes `make testios` as a test target
     """
+
     buildersuffix = ".iOS-simulator"
     ios_min_version = ""  # use the default from the configure file
     factory_tags = ["iOS"]
@@ -1045,146 +1046,181 @@ class _IOSSimulatorBuild(UnixBuild):
         super().__init__(source, **kwargs)
 
     def setup(self, parallel, branch, test_with_PTY=False, **kwargs):
-        out_of_tree_dir = "build_oot"
-        oot_dir_path = os.path.join("build", out_of_tree_dir)
-        oot_build_path = os.path.join(oot_dir_path, "build")
-        oot_host_path = os.path.join(oot_dir_path, "host")
+        if branch in {"3.13", "3.14"}:
+            out_of_tree_dir = "build_oot"
+            oot_dir_path = os.path.join("build", out_of_tree_dir)
+            oot_build_path = os.path.join(oot_dir_path, "build")
+            oot_host_path = os.path.join(oot_dir_path, "host")
 
-        # Create out of tree directory for "build", the platform we are
-        # currently running on
-        self.addStep(
-            ShellCommand(
-                name="mkdir build out-of-tree directory",
-                description="Create build out-of-tree directory",
-                command=["mkdir", "-p", oot_build_path],
-                warnOnFailure=True,
+            # Create out of tree directory for "build", the platform we are
+            # currently running on
+            self.addStep(
+                ShellCommand(
+                    name="mkdir build out-of-tree directory",
+                    description="Create build out-of-tree directory",
+                    command=["mkdir", "-p", oot_build_path],
+                    warnOnFailure=True,
+                )
             )
-        )
-        # Create directory for "host", the platform we want to compile *for*
-        self.addStep(
-            ShellCommand(
-                name="mkdir host out-of-tree directory",
-                description="Create host out-of-tree directory",
-                command=["mkdir", "-p", oot_host_path],
-                warnOnFailure=True,
+            # Create directory for "host", the platform we want to compile *for*
+            self.addStep(
+                ShellCommand(
+                    name="mkdir host out-of-tree directory",
+                    description="Create host out-of-tree directory",
+                    command=["mkdir", "-p", oot_host_path],
+                    warnOnFailure=True,
+                )
             )
-        )
 
-        # First, we build the "build" Python, which we need to cross compile
-        # the "host" Python
-        self.addStep(
-            Configure(
-                name="Configure build Python",
-                command=["../../configure"],
-                workdir=oot_build_path
+            # First, we build the "build" Python, which we need to cross compile
+            # the "host" Python
+            self.addStep(
+                Configure(
+                    name="Configure build Python",
+                    command=["../../configure"],
+                    workdir=oot_build_path,
+                )
             )
-        )
-        if parallel:
-            compile = ["make", parallel]
-        else:
-            compile = ["make"]
+            if parallel:
+                compile = ["make", parallel]
+            else:
+                compile = ["make"]
 
-        self.addStep(
-            Compile(
-                name="Compile build Python",
-                command=compile,
-                workdir=oot_build_path
+            self.addStep(
+                Compile(
+                    name="Compile build Python", command=compile, workdir=oot_build_path
+                )
             )
-        )
 
-        # Ensure the host path is isolated from Homebrew et al, but includes
-        # the host helper binaries. Also add the configuration paths for
-        # library dependencies.
-        support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
-        compile_environ = dict(self.compile_environ)
-        compile_environ.update({
-            "PATH": os.pathsep.join([
-                # This is intentionally a relative path. Buildbot doesn't expose
-                # the absolute working directory where the build is running as
-                # something that can be expanded into an environment variable.
-                "../../iOS/Resources/bin",
-                "/usr/bin",
-                "/bin",
-                "/usr/sbin",
-                "/sbin",
-                "/Library/Apple/usr/bin",
-            ]),
-            "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
-            "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
-            "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
-            "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
-            "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
-            "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
-        })
+            # Ensure the host path is isolated from Homebrew et al, but includes
+            # the host helper binaries. Also add the configuration paths for
+            # library dependencies.
+            support_path = f"/Users/buildbot/support/iphonesimulator.{self.arch}"
+            compile_environ = dict(self.compile_environ)
+            compile_environ.update(
+                {
+                    "PATH": os.pathsep.join(
+                        [
+                            # This is intentionally a relative path. Buildbot doesn't expose
+                            # the absolute working directory where the build is running as
+                            # something that can be expanded into an environment variable.
+                            "../../iOS/Resources/bin",
+                            "/usr/bin",
+                            "/bin",
+                            "/usr/sbin",
+                            "/sbin",
+                            "/Library/Apple/usr/bin",
+                        ]
+                    ),
+                    "LIBLZMA_CFLAGS": f"-I{support_path}/xz/include",
+                    "LIBLZMA_LIBS": f"-L{support_path}/xz/lib -llzma",
+                    "BZIP2_CFLAGS": f"-I{support_path}/bzip2/include",
+                    "BZIP2_LIBS": f"-L{support_path}/bzip2/lib -lbz2",
+                    "LIBFFI_CFLAGS": f"-I{support_path}/libffi/include",
+                    "LIBFFI_LIBS": f"-L{support_path}/libffi/lib -lffi",
+                }
+            )
 
-        # Now that we have a "build" architecture Python, we can use that
-        # to build a "host" (also known as the target we are cross compiling)
-        # Take a copy so that the class-level definition isn't tainted
-        configure_cmd = list(self.host_configure_cmd)
-        configure_cmd += self.configureFlags
-        configure_cmd += self.extra_configure_flags
-        configure_cmd += [
-            f"--with-openssl={support_path}/openssl",
-            f"--build={self.arch}-apple-darwin",
-            f"--host={self.host}",
-            "--with-build-python=../build/python.exe",
-            "--enable-framework"
-        ]
+            # Now that we have a "build" architecture Python, we can use that
+            # to build a "host" (also known as the target we are cross compiling)
+            # Take a copy so that the class-level definition isn't tainted
+            configure_cmd = list(self.host_configure_cmd)
+            configure_cmd += self.configureFlags
+            configure_cmd += self.extra_configure_flags
+            configure_cmd += [
+                f"--with-openssl={support_path}/openssl",
+                f"--build={self.arch}-apple-darwin",
+                f"--host={self.host}",
+                "--with-build-python=../build/python.exe",
+                "--enable-framework",
+            ]
 
-        self.addStep(
-            Configure(
-                name="Configure host Python",
-                command=configure_cmd,
-                env=compile_environ,
-                workdir=oot_host_path
+            self.addStep(
+                Configure(
+                    name="Configure host Python",
+                    command=configure_cmd,
+                    env=compile_environ,
+                    workdir=oot_host_path,
+                )
             )
-        )
 
-        if parallel:
-            compile = ["make", parallel, self.makeTarget]
-            install = ["make", parallel, "install"]
-        else:
-            compile = ["make", self.makeTarget]
-            install = ["make", "install"]
+            if parallel:
+                compile = ["make", parallel, self.makeTarget]
+                install = ["make", parallel, "install"]
+            else:
+                compile = ["make", self.makeTarget]
+                install = ["make", "install"]
 
-        self.addStep(
-            Compile(
-                name="Compile host Python",
-                command=compile,
-                env=compile_environ,
-                workdir=oot_host_path,
+            self.addStep(
+                Compile(
+                    name="Compile host Python",
+                    command=compile,
+                    env=compile_environ,
+                    workdir=oot_host_path,
+                )
             )
-        )
-        self.addStep(
-            Compile(
-                name="Install host Python",
-                command=install,
-                env=compile_environ,
-                workdir=oot_host_path,
+            self.addStep(
+                Compile(
+                    name="Install host Python",
+                    command=install,
+                    env=compile_environ,
+                    workdir=oot_host_path,
+                )
             )
-        )
-        self.addStep(
-            Test(
-                command=["make", "testios"],
-                timeout=step_timeout(self.test_timeout),
-                usePTY=test_with_PTY,
-                env=self.test_environ,
-                workdir=oot_host_path,
+            self.addStep(
+                Test(
+                    command=["make", "testios"],
+                    timeout=step_timeout(self.test_timeout),
+                    usePTY=test_with_PTY,
+                    env=self.test_environ,
+                    workdir=oot_host_path,
+                )
             )
-        )
 
-        self.addStep(
-            Clean(
-                name="Clean build Python",
-                workdir=oot_build_path,
+            self.addStep(
+                Clean(
+                    name="Clean build Python",
+                    workdir=oot_build_path,
+                )
             )
-        )
-        self.addStep(
-            Clean(
-                name="Clean host Python",
-                workdir=oot_host_path,
+            self.addStep(
+                Clean(
+                    name="Clean host Python",
+                    workdir=oot_host_path,
+                )
             )
-        )
+        else:  # Builds of Python 3.15+
+            self.addSteps(
+                [
+                    Compile(
+                        name="Configure and compile build Python",
+                        command=["python3", "Platforms/Apple", "build", "iOS", "build"],
+                    ),
+                    Compile(
+                        name="Configure and compile host Pythons",
+                        command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
+                    ),
+                    Compile(
+                        name="Package XCframework",
+                        command=["python3", "Platforms/Apple", "package", "iOS"],
+                    ),
+                    Test(
+                        name="Run test suite",
+                        command=[
+                            "python3",
+                            "Platforms/Apple",
+                            "iOS",
+                            "test",
+                            "--slow-ci",
+                        ],
+                        timeout=step_timeout(self.test_timeout),
+                    ),
+                    Clean(
+                        name="Clean the builds",
+                        command=["python3", "Platforms/Apple", "clean", "iOS"],
+                    ),
+                ]
+            )
 
 
 class IOSARM64SimulatorBuild(_IOSSimulatorBuild):

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1202,7 +1202,7 @@ class _IOSSimulatorBuild(UnixBuild):
             self.addSteps(
                 [
                     ShellCommand(
-                        name="Set up compatibility symlink (will fail on <= 3.13 branches)",
+                        name="Set up compatibility symlink",
                         command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
                     ),
                     Compile(


### PR DESCRIPTION
The iOS XCframework build script will shortly be moved to `Platforms/iOS`. 

This updates the Buildbot config to use the new XCframework buildbot in "slow" mode for 3.15+ builds (ensuring a full, multi-architecture XCframework is built and tested.

~~I haven't pushed the corresponding CPython PR yet; this is to explore options for branch-based configuration of the build script.~~

~~As I currently understand it, this will work for buildbot runs that are triggered on a merge of a PR on main, 3.13, 3.14, or the 3.15 branch (when it is forked). A PR build will succeed on main and 3.15 (when it is forked). But a PR build based off a 3.13/3.14 branch will fail (because there's currently no way to identify the base branch of a PR job).~~

python/cpython#146497 has the changes necessary for this build script to work.

It introduces a symlink for 3.14 compatibility. It falls back to the old build script for builds explicitly on the 3.13 branch. PR builds based off a 3.13 branch will fail as the XCframework script wasn't introduced until 3.14, and there's not currently any way to identify the base branch for a "custom" PR build.
