### PR TITLE
Fix makeTarget in UnixCrossBuild

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -834,7 +834,7 @@ class UnixCrossBuild(UnixBuild):
             f"TESTTIMEOUT={self.test_timeout}",
         ]
 
-        compile = [*self.host_make_cmd, *get_j_opts(worker), *self.makeTarget]
+        compile = [*self.host_make_cmd, *get_j_opts(worker), self.makeTarget]
         self.addStep(
             Compile(
                 name="Compile host Python",


### PR DESCRIPTION
I added an extra star in afb509e4338a66466f07277bf1f467552c6c2ee0, leading to failing wasm32-wasi builds on 3.11-3.12:

```
$ make -j2 a l l
make: *** No rule to make target 'a'.  Stop.
```