### PR TITLE
Add a compatibility shim for migrating Android build tools to Platforms

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1195,8 +1195,9 @@ class _IOSSimulatorBuild(UnixBuild):
             ShellCommand(
                 name="Set up compatibility symlink",
                 command=(
-                    "[ -e Platforms/Apple ] "
-                    "|| ln -s ../Apple Platforms/Apple"
+                    "if [ ! -e Platforms/Apple ]; then"
+                    " ln -s ../Apple Platforms/Apple; "
+                    "fi"
                 ),
             ),
             # Build the full iOS XCframework, including a multi-arch simulator slice.
@@ -1277,10 +1278,11 @@ class AndroidBuild(BaseBuild):
             ShellCommand(
                 name="Set up compatibility symlink",
                 command=(
-                    "[ -e Platforms/Android ] "
-                    "|| mkdir -p Platforms "
-                    "&& ln -s ../Android Platforms/Android "
-                    "&& ln -s ../Android/android.py Platforms/Android/__main__.py"
+                    "if [ ! -e Platforms/Android ]; then"
+                    " mkdir -p Platforms;"
+                    " ln -s ../Android Platforms/Android;"
+                    " ln -s ../Android/android.py Platforms/Android/__main__.py; "
+                    "fi"
                 ),
             ),
             SetPropertyFromCommand(

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1280,7 +1280,7 @@ class AndroidBuild(BaseBuild):
                     "[ -e Platforms/Android ] "
                     "|| mkdir -p Platforms "
                     "&& ln -s ../Android Platforms/Android "
-                    "&& ln -si ../Android/android.py Platforms/Android/__main__.py"
+                    "&& ln -s ../Android/android.py Platforms/Android/__main__.py"
                 ),
             ),
             SetPropertyFromCommand(

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1185,10 +1185,7 @@ class _IOSSimulatorBuild(UnixBuild):
         )
 
     def current_setup(self, branch, worker, test_with_PTY=False, **kwargs):
-        build_environ = {
-            "CACHE_DIR": "/Users/buildbot/downloads",
-        }
-
+        apple_py = ["python3", "Platforms/Apple"]
         self.addSteps([
             # This symlink is needed to support Python 3.14 builds - it makes the
             # top level Apple folder appear in the new Platforms/Apple location.
@@ -1202,18 +1199,15 @@ class _IOSSimulatorBuild(UnixBuild):
             # Build the full iOS XCframework, including a multi-arch simulator slice.
             Compile(
                 name="Configure and compile build Python",
-                command=["python3", "Platforms/Apple", "build", "iOS", "build"],
-                env=build_environ,
+                command=apple_py + ["build", "iOS", "build"],
             ),
             Compile(
                 name="Configure and compile host Pythons",
-                command=["python3", "Platforms/Apple", "build", "iOS", "hosts"],
-                env=build_environ,
+                command=apple_py + ["build", "iOS", "hosts"],
             ),
             Compile(
                 name="Package XCframework",
-                command=["python3", "Platforms/Apple", "package", "iOS"],
-                env=build_environ,
+                command=apple_py + ["package", "iOS"],
             ),
             Test(
                 name="Run test suite",
@@ -1224,13 +1218,11 @@ class _IOSSimulatorBuild(UnixBuild):
                     "iOS",
                     "--slow-ci",
                 ],
-                env=build_environ,
                 timeout=step_timeout(self.test_timeout),
             ),
             Clean(
                 name="Clean the builds",
-                command=["python3", "Platforms/Apple", "clean", "iOS"],
-                env=build_environ,
+                command=apple_py + ["clean", "iOS"],
             ),
         ])
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1281,7 +1281,7 @@ class AndroidBuild(BaseBuild):
                     "if [ ! -e Platforms/Android ]; then"
                     " mkdir -p Platforms;"
                     " ln -s ../Android Platforms/Android;"
-                    " ln -s ../Android/android.py Platforms/Android/__main__.py; "
+                    " ln -s ./android.py Platforms/Android/__main__.py; "
                     "fi"
                 ),
             ),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1194,7 +1194,10 @@ class _IOSSimulatorBuild(UnixBuild):
             # supported.
             ShellCommand(
                 name="Set up compatibility symlink",
-                command="[ -e Platforms/Apple ] || ln -s ../Apple Platforms/Apple",
+                command=(
+                    "[ -e Platforms/Apple ] "
+                    "|| ln -s ../Apple Platforms/Apple"
+                ),
             ),
             # Build the full iOS XCframework, including a multi-arch simulator slice.
             Compile(
@@ -1268,14 +1271,15 @@ class AndroidBuild(BaseBuild):
         android_py = ["python3", "Platforms/Android"]
         self.addSteps([
             # This symlink is needed to support pre Python 3.15 builds - it makes the
-            # top level Andrdoid folder appear in the new Platforms/Android location,
+            # top level Android folder appear in the new Platforms/Android location,
             # and links `__main__.py` to the older `android.py` script. This step can
             # be removed when 3.14 is no longer supported.
             ShellCommand(
                 name="Set up compatibility symlink",
                 command=(
-                    "[ -e Platforms/Android ]"
-                    "|| ln -s ../Android Platforms/Android"
+                    "[ -e Platforms/Android ] "
+                    "|| mkdir -p Platforms "
+                    "&& ln -s ../Android Platforms/Android "
                     "&& ln -si ../Android/android.py Platforms/Android/__main__.py"
                 ),
             ),

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -1273,8 +1273,20 @@ class AndroidBuild(BaseBuild):
     """
 
     def setup(self, **kwargs):
-        android_py = "Android/android.py"
+        android_py = ["python3", "Platforms/Android"]
         self.addSteps([
+            # This symlink is needed to support pre Python 3.15 builds - it makes the
+            # top level Andrdoid folder appear in the new Platforms/Android location,
+            # and links `__main__.py` to the older `android.py` script. This step can
+            # be removed when 3.14 is no longer supported.
+            ShellCommand(
+                name="Set up compatibility symlink",
+                command=(
+                    "[ -e Platforms/Android ]"
+                    "|| ln -s ../Android Platforms/Android"
+                    "&& ln -si ../Android/android.py Platforms/Android/__main__.py"
+                ),
+            ),
             SetPropertyFromCommand(
                 name="Get build triple",
                 command=["./config.guess"],
@@ -1283,24 +1295,22 @@ class AndroidBuild(BaseBuild):
             ),
             Configure(
                 name="Configure build Python",
-                command=[android_py, "configure-build"],
+                command=android_py + ["configure-build"],
             ),
             Compile(
                 name="Compile build Python",
-                command=[android_py, "make-build"],
+                command=android_py + ["make-build"],
             ),
             Configure(
                 name="Configure host Python",
-                command=[android_py, "configure-host", self.host_triple],
+                command=android_py + ["configure-host", self.host_triple],
             ),
             Compile(
                 name="Compile host Python",
-                command=[android_py, "make-host", self.host_triple],
+                command=android_py + ["make-host", self.host_triple],
             ),
             Test(
-                command=[
-                    android_py, "test", "--managed", "maxVersion", "-v", "--slow-ci"
-                ],
+                command=android_py + ["test", "--managed", "maxVersion", "-v", "--slow-ci"],
                 timeout=step_timeout(self.test_timeout),
             ),
         ])


### PR DESCRIPTION
Following the pattern used by the iOS build, adds a compatibility shim so that the buildbot will *run* `Platforms/Android`, but that location will work on 3.13 and 3.14 repos that store the Android build code in `Android/android.py`.

Also updates the iOS configuration to use the same general pattern for invoking the build script.

As part of this, the `CACHE_DIR` configuration has been moved *out* of the buildbot definition, and into the environment where the buildbot is executed. This means the buildbot configuration is no longer sensitive to the specific user account that is hosting the buildbot instance.

This configuration can be landed now, without the `Platforms` migration having been made - the Android folder exists in all 3.13+ repos as of right now. Once the Platforms migration occurs the symlink step will become a no-op.