### PR TITLE
Only run `diegorusso-aarch64-bigmem` on `3.x` (aka `main`)

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -170,7 +170,7 @@ def get_workers(settings):
         cpw(
             name="diegorusso-aarch64-bigmem",
             tags=['linux', 'unix', 'ubuntu', 'arm', 'arm64', 'aarch64', 'bigmem'],
-            not_branches=['3.10', '3.11', '3.12', '3.13', '3.14'],
+            branches=['3.x'],
             parallel_tests=8,
             # This worker runs pyperformance for speed.python.org at 12am UTC.
             # The pyperformance run lasts less than 2h.


### PR DESCRIPTION
Can we say `branches=['3.x']`? That'll be better than always tagging on the new branch.

cc @diegorusso 