### PR TITLE
release_dashboard: Refresh branch information before re-rendering

### DIFF
--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import os
 import time
@@ -737,10 +738,8 @@ class ReleaseDashboard:
                 if time.monotonic() <= deadline:
                     return result
 
-                try:
-                    self._refresh_branch_info()
-                except urllib.error.HTTPError:
-                    pass
+            with contextlib.suppress(urllib.error.HTTPError):
+                self._refresh_branch_info()
 
             result = self.get_release_status()
             deadline = time.monotonic() + CACHE_DURATION


### PR DESCRIPTION
Turns out the try/except was indented a bit far; bump it back out and
compact it with contextlib.suppress.

Fixes #715.
