### PR TITLE
Retire ware-freebsd worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -168,7 +168,6 @@ STABLE_BUILDERS_TIER_3 = [
     ("ARM64 Raspbian Debug", "savannah-raspbian", SlowDebugUnixBuild),
 
     # FreBSD x86-64 clang
-    ("AMD64 FreeBSD", "ware-freebsd", UnixBuild),
     ("AMD64 FreeBSD Refleaks", "opsec-fbsd14", UnixRefleakBuild),
     ("AMD64 FreeBSD14", "opsec-fbsd14", UnixBuild),
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -266,11 +266,6 @@ def get_workers(settings):
             parallel_tests=6,
         ),
         cpw(
-            name="ware-freebsd",
-            tags=['freebsd', 'bsd', 'unix', 'amd64', 'x86-64'],
-            parallel_tests=6,
-        ),
-        cpw(
             name="opsec-fbsd14",
             tags=['freebsd', 'bsd', 'unix', 'amd64', 'x86-64'],
             parallel_tests=4,


### PR DESCRIPTION
FreeBSD 13 has reached end-of-life, and newer FreeBSDs are
already well covered.
