### PR TITLE
Use partial (blobless) git clones and auto-recovery on fetch failure

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -139,6 +139,11 @@ GIT_KWDS = {
     # ignoring the .gitignore rules (ex: remove also ".o" files).
     "mode": "full",
     "method": "fresh",
+    # Partial (blobless) clone: only fetch commit and tree objects,
+    # blobs are fetched on demand during checkout.
+    "filters": ["blob:none"],
+    # If fetch fails, wipe and re-clone instead of failing the build.
+    "clobberOnFailure": True,
 }
 
 c["builders"] = []


### PR DESCRIPTION
Enable filters=["blob:none"] for partial clones reducing .git/objects from ~800MB to ~250MB per build directory.

Enable clobberOnFailure so failed fetches wipe and re-clone instead of failing the build.