### PR TITLE
Inline builder source config

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -128,23 +128,7 @@ c["caches"] = {
 # workers are set up in workers.py
 c["workers"] = [w.bb_worker for w in WORKERS]
 
-GIT_URL = str(settings.git_url)
-
 # git_branches used to be here; moved to branches.py
-
-# common Git() and GitHub() keyword arguments
-GIT_KWDS = {
-    "timeout": 3600,
-    # "git clean -fdx": remove all files which are not tracked by Git,
-    # ignoring the .gitignore rules (ex: remove also ".o" files).
-    "mode": "full",
-    "method": "fresh",
-    # Partial (blobless) clone: only fetch commit and tree objects,
-    # blobs are fetched on demand during checkout.
-    "filters": ["blob:none"],
-    # If fetch fails, wipe and re-clone instead of failing the build.
-    "clobberOnFailure": True,
-}
 
 c["builders"] = []
 c["schedulers"] = []
@@ -221,9 +205,24 @@ for branch in BRANCHES:
         buildername = name + " " + branch.name
 
         if branch.is_pr:
-            source = GitHub(repourl=GIT_URL, **GIT_KWDS)
+            branch_args = {}
         else:
-            source = Git(repourl=GIT_URL, branch=branch.git_branch, **GIT_KWDS)
+            branch_args = {'branch': branch.git_branch}
+
+        source = GitHub(
+            repourl=str(settings.git_url),
+            timeout=3600,
+            **branch_args,
+            # "git clean -fdx": remove all files which are not tracked by Git,
+            # ignoring the .gitignore rules (ex: remove also ".o" files).
+            mode="full",
+            method="fresh",
+            # Partial (blobless) clone: only fetch commit and tree objects,
+            # blobs are fetched on demand during checkout.
+            filters=["blob:none"],
+            # If fetch fails, wipe and re-clone instead of failing the build.
+            clobberOnFailure=True,
+        )
 
         f = buildfactory(
             source,


### PR DESCRIPTION

Use the `GitHub` source also for non-PR builders; it should work like Git.
Inline GIT_KWDS and GIT_URL, now that they're only used in one place.

---

After a break for b1 & PyCon, I'm getting back to PRs with individual changes from @zware's branch, to review/test/fixup/revert the changes one by one. This is a follow-up to 3b06cdf3b77648cf09beda0876c51bcd1dae318e, also based on [45b7b4a](https://github.com/zware/buildmaster-config/commit/45b7b4a).
