### PR TITLE
Use max_builds instead of a lock

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -30,7 +30,7 @@ class CPythonWorker:
         tags=None,
         branches=None,
         not_branches=None,
-        parallel_builders=None,
+        parallel_builders=1,
         parallel_tests=None,
         timeout_factor=1,
         exclude_test_resources=None,
@@ -40,7 +40,6 @@ class CPythonWorker:
         self.tags = tags or set()
         self.branches = branches
         self.not_branches = not_branches
-        self.parallel_builders = parallel_builders
         self.parallel_tests = parallel_tests
         self.timeout_factor = timeout_factor
         self.exclude_test_resources = exclude_test_resources or []
@@ -60,7 +59,7 @@ class CPythonWorker:
                 str(pw),
                 notify_on_missing=emails,
                 keepalive_interval=KEEPALIVE,
-                max_builds=parallel_builders or 1,
+                max_builds=parallel_builders,
             )
 
 # Some of Itamar's workers are reprovisioned every Wednesday at 9am PT.

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -55,9 +55,13 @@ class CPythonWorker:
         if settings.use_local_worker:
             self.bb_worker = _worker.LocalWorker(name)
         else:
-            self.bb_worker = _worker.Worker(name, str(pw),
-                                            notify_on_missing=emails,
-                                            keepalive_interval=KEEPALIVE)
+            self.bb_worker = _worker.Worker(
+                name,
+                str(pw),
+                notify_on_missing=emails,
+                keepalive_interval=KEEPALIVE,
+                max_builds=parallel_builders or 1,
+            )
 
 # Some of Itamar's workers are reprovisioned every Wednesday at 9am PT.
 # Builds scheduled between 8am - 10am PT on Wednesdays will be delayed to

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -149,14 +149,6 @@ GIT_KWDS = {
 c["builders"] = []
 c["schedulers"] = []
 
-# The following with the worker owners' agreement
-cpulock = locks.WorkerLock(
-    "cpu",
-    maxCountForWorker={
-        w.name: w.parallel_builders for w in WORKERS if w.parallel_builders
-    },
-)
-
 
 def is_important_file(filename):
     unimportant_prefixes = (
@@ -274,7 +266,6 @@ for branch in BRANCHES:
             builddir=f"{branch.builddir_name}.{worker.name}{f.buildersuffix}",
             factory=f,
             tags=tags,
-            locks=[cpulock.access("counting")],
         )
 
         if worker.downtime:


### PR DESCRIPTION
Use the `max_builds` argument for `Worker` rather than an extra lock with per-worker settings.

---

I'm sending PRs with individual changes from @zware's branch, to review/test/fixup/revert the changes one by one. This is based on [6fc7966](https://github.com/zware/buildmaster-config/commit/6fc7966).