### PR TITLE
Make `buildbot.sh` and `make git-update-requirements` more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ git-update-requirements:
 	git pull
 	git switch -c reqs main
 	make regen-requirements
-	git ci -a -m "Run make regen-requirements"
+	git commit -a -m "Run make regen-requirements"
 
 .PHONY: help
 help : Makefile

--- a/buildbot.sh
+++ b/buildbot.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /srv/buildbot/venv/bin/buildbot $@
+exec $(dirname $0)/venv/bin/buildbot $@


### PR DESCRIPTION
- `Makefile`: Avoid a custom alias for `git commit`
- `buildbot.sh`: Use the directory of the script rather than the production path

---

The second one is [9f8b1095](https://github.com/zware/buildmaster-config/commit/9f8b1095a989540d1db215d772949be1b2303962) from @zware's branch.