### PR TITLE
Tidy up Discord notification formatting

### DIFF
--- a/master/custom/discord_reporter.py
+++ b/master/custom/discord_reporter.py
@@ -23,15 +23,9 @@ from custom.testsuite_utils import get_logs_and_tracebacks_from_build
 MESSAGE = """\
 :warning: **Buildbot failure** :warning:
 
-The buildbot **{buildername}** ({tier}) has failed when building commit {sha}(https://github.com/python/cpython/commit/{sha}).
+The buildbot **{buildername}** ({tier}) has failed when building commit [{sha:.12}](https://github.com/python/cpython/commit/{sha}).
 
-You can take a look at the buildbot page here:
-
-{build_url}
-
-```
-{failed_test_text}
-```
+[Jump to the build page.]({build_url})
 """
 
 
@@ -159,8 +153,11 @@ class DiscordReporter(reporters.HttpStatusPush):
                 builder["builderid"], build["number"]
             ),
             sha=sha,
-            failed_test_text=logs.format_failing_tests(),
         )
+
+        failed_test_text = logs.format_failing_tests()
+        if failed_test_text and failed_test_text.strip():
+            message += "\n```\n{}\n```\n".format(failed_test_text)
 
         payload = {"content": message, "embeds": []}
 


### PR DESCRIPTION
Some notifications currently look like so:

<img width="1325" height="386" alt="image" src="https://github.com/user-attachments/assets/c2b6b34f-674e-4668-bea6-a877fbdf695e" />

With this patch, it would instead look like so:

<img width="957" height="263" alt="image" src="https://github.com/user-attachments/assets/e556c25f-c6b2-4739-8095-7242f5412b54" />
