### PR TITLE
Increase test_timeout on cstratak-*-ppc64le

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -131,11 +131,13 @@ def get_workers(settings):
             name="cstratak-fedora-rawhide-ppc64le",
             tags=['linux', 'unix', 'fedora', 'ppc64le'],
             parallel_tests=10,
+            timeout_factor=2,  # Increase the timeout on this slow worker
         ),
         cpw(
             name="cstratak-fedora-stable-ppc64le",
             tags=['linux', 'unix', 'fedora', 'ppc64le'],
             parallel_tests=10,
+            timeout_factor=2,  # Increase the timeout on this slow worker
         ),
         cpw(
             name="cstratak-RHEL8-ppc64le",
@@ -148,6 +150,7 @@ def get_workers(settings):
             name="cstratak-CentOS9-ppc64le",
             tags=['linux', 'unix', 'rhel', 'ppc64le'],
             parallel_tests=10,
+            timeout_factor=2,  # Increase the timeout on this slow worker
         ),
         cpw(
             name="cstratak-fedora-rawhide-aarch64",


### PR DESCRIPTION
`test_tools` has been timing out on PPC64LE CentOS9 LTO. Perhaps it's time to increase the timeout.

Note the timeout was increased for RHEL8 (i.e. older CPython branches) in #468; this increases it for the other workers.