### PR TITLE
Add a new `rise-riscv64-4` worker

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -420,6 +420,9 @@ BUILDER_DEFS.extend(generate_builderdefs({UNSTABLE}, [
 
     # Arch Usan (see stable "AMD64 Arch Linux Usan Function" above)
     ("AMD64 Arch Linux Usan", "pablogsal-arch-x86_64", ClangUbsanLinuxBuild),
+
+    # RISC-V 64-bit GCC
+    ("RISC-V 64-bit Ubuntu", "rise-riscv64-4", SlowDebugUnixBuild)
 ]))
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -225,6 +225,12 @@ def get_workers(settings):
             parallel_tests=4,
         ),
         cpw(
+            name="rise-riscv64-4",
+            tags=['linux', 'unix', 'ubuntu', 'riscv64'],
+            not_branches=['3.10'],
+            parallel_tests=4,
+        ),
+        cpw(
             name="stan-aarch64-ubuntu",
             tags=['linux', 'unix', 'ubuntu', 'arm', 'arm64', 'aarch64'],
             parallel_tests=4,


### PR DESCRIPTION
This machine will be about ~twice-thrice as fast as the current Buildbot, so I think we can try debug builds on it. If it's too slow, we might have to re-consider. Draft pending https://github.com/python/buildmaster-config/issues/757.