### PR TITLE
Move `RISC-V 64-bit Ubuntu {Clang}` to stable no tier builders

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -303,8 +303,10 @@ BUILDER_DEFS.extend(generate_builderdefs({STABLE}, [
     ("x86 Debian Non-Debug with X", "ware-debian-x86", NonDebugUnixBuild),
     ("x86 Debian Installed with X", "ware-debian-x86", UnixInstalledBuild),
 
-    # riscv64 GCC
+    # RISC-V 64-bit GCC/Clang
     ("riscv64 Ubuntu", "onder-riscv64", SlowUnixInstalledBuild),
+    ("RISC-V 64-bit Ubuntu", "rise-riscv64-4", SlowDebugUnixBuild),
+    ("RISC-V 64-bit Ubuntu Clang", "rise-riscv64-2", SlowClangUnixBuild),
 ]))
 
 
@@ -432,9 +434,7 @@ BUILDER_DEFS.extend(generate_builderdefs({UNSTABLE}, [
     ("AMD64 Arch Linux Usan", "pablogsal-arch-x86_64", ClangUbsanLinuxBuild),
 
     # RISC-V 64-bit GCC
-    ("RISC-V 64-bit Ubuntu", "rise-riscv64-4", SlowDebugUnixBuild),
     ("RISC-V 64-bit Ubuntu NoGIL", "rise-riscv64-3", SlowUnixNoGilBuild),
-    ("RISC-V 64-bit Ubuntu Clang", "rise-riscv64-2", SlowClangUnixBuild),
 ]))
 
 

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -232,19 +232,19 @@ def get_workers(settings):
         cpw(
             name="rise-riscv64-2",
             tags=['linux', 'unix', 'ubuntu', 'riscv64'],
-            not_branches=['3.10'],
+            not_branches=['3.10', '3.11'],
             parallel_tests=4,
         ),
         cpw(
             name="rise-riscv64-3",
             tags=['linux', 'unix', 'ubuntu', 'riscv64'],
-            not_branches=['3.10'],
+            not_branches=['3.10', '3.11'],
             parallel_tests=4,
         ),
         cpw(
             name="rise-riscv64-4",
             tags=['linux', 'unix', 'ubuntu', 'riscv64'],
-            not_branches=['3.10'],
+            not_branches=['3.10', '3.11'],
             parallel_tests=4,
         ),
         cpw(


### PR DESCRIPTION
These have been green for the last week, bar a few yellows, but those should be resolved by https://github.com/python/cpython/commit/8ca85b5bc5a888b8329915aff0ceb34de9373546. Free-threading is similar, but it does seem to have a few flaky tests. I'll wait a little bit more before merging.