### PR TITLE
Move Windows refleak builds on maintenance branches to ware-ws2025, other branch cleanups

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -146,8 +146,9 @@ BUILDER_DEFS = [
     BuilderDef(
         "AMD64 Windows Server 2025 Refleaks",
         factories.Windows64RefleakBuild,
-        tags={UNSTABLE, TIER_1},
+        tags={STABLE, TIER_1},
         worker_name="ware-ws2025",
+        branches=BRANCHES.only_since(3, 13),
     ),
     BuilderDef(
         "AMD64 Windows PGO",

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -198,7 +198,13 @@ BUILDER_DEFS.extend(generate_builderdefs({STABLE, TIER_1}, [
     # Windows x86-64 MSVC
     ("AMD64 Windows10", "bolen-windows10", Windows64Build),
     ("AMD64 Windows11 Non-Debug", "ware-win11", Windows64ReleaseBuild),
-    ("AMD64 Windows11 Refleaks", "ware-win11", Windows64RefleakBuild),
+    BuilderDef(
+        "AMD64 Windows11 Refleaks",
+        factories.Windows64RefleakBuild,
+        tags={STABLE, TIER_1},
+        worker_name="ware-win11",
+        branches=BRANCHES.only_until(3, 12),
+    ),
     ("AMD64 Windows Server 2022 NoGIL", "itamaro-win64-srv-22-aws", Windows64NoGilBuild),
     BuilderDef(
         "AMD64 Windows PGO Tailcall",

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -691,6 +691,7 @@ class Windows64ClangBuild(Windows64Build):
         "PlatformToolset": "ClangCL",
     }
     factory_tags = [*Windows64Build.factory_tags, 'clang']
+    branches = BRANCHES.only_since(3, 14)
 
 
 class Windows64BigmemBuild(BaseWindowsBuild):


### PR DESCRIPTION
- **Restrict ClangCL builds to 3.14+**
- **Stabilize refleak builds on ware-ws2025 since 3.13**
- **Remove 3.13+ refleak builds from ware-win11**
