### PR TITLE
Remove no-branch from release dashboard

### DIFF
--- a/master/custom/release_dashboard.py
+++ b/master/custom/release_dashboard.py
@@ -122,7 +122,6 @@ class DashboardState(DashboardObject):
             branches.append(Branch(self, {
                 **info, 'version': version, 'tag': tag
             }))
-        branches.append(self._no_branch)
         return branches
 
     @cached_property

--- a/master/custom/templates/releasedashboard.html
+++ b/master/custom/templates/releasedashboard.html
@@ -120,9 +120,6 @@
 
     <div class="branch-panels">
         {% for branch in state.branches %}
-            {% if branch.tag == 'no-branch' %}
-                {% continue %}
-            {% endif %}
             <div
                 class="branch-panel panel-{{ branch.featured_problem.severity.css_color_class }}"
                 {#- Buildbot's React UI takes over `#` in the URL, so a HTML fragment link won't work here...  #}


### PR DESCRIPTION
Does anyone use the no-branch section of the [release dashboard](https://buildbot.python.org/#/release_status)?

<img width="284" height="255" alt="image" src="https://github.com/user-attachments/assets/c13a699f-d384-403c-b483-f7c4f59d21fc" />

If not, let's remove it. This would save fetching data for 142 of the 1,074 builders listed on the page, about 13%.

A cached page takes about 2s:

```console
❯ curl -s -o /dev/null -w "ttfb: %{time_starttransfer}s  total: %{time_total}s\n" \
    "https://buildbot.python.org/plugins/wsgi_dashboards/release_status/index.html"
ttfb: 0.637072s  total: 2.030991s
```

Forcing a refresh:

```console
❯ curl -s -o /dev/null -w "ttfb: %{time_starttransfer}s  total: %{time_total}s\n" \
    "https://buildbot.python.org/plugins/wsgi_dashboards/release_status/index.html?refresh=1"

ttfb: 25.549996s  total: 25.550114s
```

ttfb is time to first byte, and tells us when the page has already finished querying all the data it needs, so this is roughly about how long it takes to run on the server.

Dropping no-branch would bring that to about 22s, and also save about 0.9 MB of the 13.2 MB HTML page.

The cron to refresh this page is every 5 mins so it's 12 times per hour:

https://github.com/python/psf-salt/blob/05305dee04372ad00c4dd66fca14ab13e35754f3/salt/buildbot/init.sls#L99-L103
