### PR TITLE
Skip test_dtrace on RHEL/Fedora on branch 3.12 and older

### DIFF
--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -471,7 +471,6 @@ class RHEL8Build(UnixBuild):
             # possible to enable it on Fedora/RHEL. But these changes were
             # only backported up to the 3.13 branch.
             # https://github.com/python/cpython/issues/98894
-            # https://github.com/python/cpython/issues/98894
             testops.extend(('-x', 'test_dtrace'))
         return testops
 

--- a/master/custom/factories.py
+++ b/master/custom/factories.py
@@ -90,13 +90,32 @@ class UnixBuild(BaseBuild):
     test_environ = {}
     build_out_of_tree = False
 
+    def create_test_opts(self, branch, worker):
+        testopts = [*self.testFlags, *get_j_opts(worker, 2)]
+        if not has_option("-R", self.testFlags):
+            testopts.extend(("--junit-xml", JUNIT_FILENAME))
+
+        # Add excluded test resources
+        exclude_test_resources = worker.exclude_test_resources
+        if exclude_test_resources:
+            u_loc = None
+            for i, opt in enumerate(testopts):
+                if opt.startswith("-u"):
+                    u_loc = i
+                    break
+            if u_loc is not None:
+                for resource in exclude_test_resources:
+                    testopts[u_loc] += f",-{resource}"
+            else:
+                testopts.append(f"-uall,{",".join(f"-{r}" for r in exclude_test_resources)}")
+
+        return testopts
+
     def setup(self, branch, worker, test_with_PTY=False, **kwargs):
         out_of_tree_dir = "build_oot"
 
         # Adjust the timeout for this worker
         self.test_timeout *= worker.timeout_factor
-
-        exclude_test_resources = worker.exclude_test_resources
 
         # In 3.10, test_asyncio wasn't split out, and refleaks tests
         # need more time.
@@ -125,22 +144,8 @@ class UnixBuild(BaseBuild):
             Configure(command=configure_cmd, **oot_kwargs)
         )
         compile = ["make", *get_j_opts(worker), self.makeTarget]
-        testopts = [*self.testFlags, *get_j_opts(worker, 2)]
-        if not has_option("-R", self.testFlags):
-            testopts.extend(("--junit-xml", JUNIT_FILENAME))
-        # Add excluded test resources
-        if exclude_test_resources:
-            u_loc = None
-            for i, opt in enumerate(testopts):
-                if opt.startswith("-u"):
-                    u_loc = i
-                    break
-            if u_loc is not None:
-                for resource in exclude_test_resources:
-                    testopts[u_loc] += f",-{resource}"
-            else:
-                testopts.append(f"-uall,{",".join(f"-{r}" for r in exclude_test_resources)}")
 
+        testopts = self.create_test_opts(branch, worker)
         test = [
             "make",
             "buildbottest",
@@ -221,7 +226,7 @@ class UnixInstalledBuild(BaseBuild):
             major, minor = branch.version_tuple
             executable_name = f'python{major}.{minor}'
         else:
-            executable_name = f'python3'
+            executable_name = 'python3'
         installed_python = f"./target/bin/{executable_name}"
         self.addStep(
             Configure(
@@ -458,6 +463,17 @@ class RHEL8Build(UnixBuild):
     # /builddir/build/BUILD/Python-3.11: source code
     # /builddir/build/BUILD/Python-3.11/build/optimized: configure, make, tests
     build_out_of_tree = True
+
+    def create_test_opts(self, branch, worker):
+        testops = super().create_test_opts(branch, worker)
+        if branch.version_tuple and branch.version_tuple < (3, 13):
+            # In 2026, test_dtrace was enhanced and fixed which made it
+            # possible to enable it on Fedora/RHEL. But these changes were
+            # only backported up to the 3.13 branch.
+            # https://github.com/python/cpython/issues/98894
+            # https://github.com/python/cpython/issues/98894
+            testops.extend(('-x', 'test_dtrace'))
+        return testops
 
 
 class CentOS9Build(RHEL8Build):


### PR DESCRIPTION
Add UnixBuild.create_test_opts(). Override this method in RHEL8Build to add "-x test_dtrace" on branch older than 3.13.