### PR TITLE
Move `aarch64 Ubuntu 24.04 BigMem` builder to stable

### DIFF
--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -195,6 +195,9 @@ BUILDER_DEFS.extend(generate_builderdefs({STABLE, TIER_1}, [
     ("AMD64 CentOS9 NoGIL", "itamaro-centos-aws", UnixNoGilBuild),
     ("AMD64 CentOS9 NoGIL Refleaks", "itamaro-centos-aws", UnixNoGilRefleakBuild),
 
+    # Ubuntu Linux AArch64
+    ("aarch64 Ubuntu 24.04 BigMem", "diegorusso-aarch64-bigmem", UnixBigmemBuild),
+
     # Windows x86-64 MSVC
     ("AMD64 Windows10", "bolen-windows10", Windows64Build),
     ("AMD64 Windows11 Non-Debug", "ware-win11", Windows64ReleaseBuild),
@@ -382,9 +385,6 @@ BUILDER_DEFS.extend(generate_builderdefs({STABLE}, [
 
 # -- Unstable Tier-1 builders -------------------------------------------
 BUILDER_DEFS.extend(generate_builderdefs({UNSTABLE, TIER_1}, [
-    # Ubuntu Linux AArch64
-    ("aarch64 Ubuntu 24.04 BigMem", "diegorusso-aarch64-bigmem", UnixBigmemBuild),
-
     # Linux x86-64 GCC
     # Fedora Rawhide is unstable
     ("AMD64 Fedora Rawhide", "cstratak-fedora-rawhide-x86_64", FedoraRawhideBuild),


### PR DESCRIPTION
It has been going well for quite a while: https://buildbot.python.org/#/builders/1832 (Some tests were failing for a bit due to a test bug in https://github.com/python/cpython/issues/152190, but that has since been fixed.)

I'll let it run for a few more days, so I'm marking as draft.