### PR TITLE
Remove `dtrace` tag from failing CentOS9 and Fedora workers

### DIFF
--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -152,7 +152,7 @@ def get_workers(settings):
         ),
         cpw(
             name="cstratak-fedora-stable-ppc64le",
-            tags=['linux', 'unix', 'fedora', 'ppc64le', 'dtrace'],
+            tags=['linux', 'unix', 'fedora', 'ppc64le'],
             parallel_tests=10,
             timeout_factor=2,  # Increase the timeout on this slow worker
         ),
@@ -165,7 +165,7 @@ def get_workers(settings):
         ),
         cpw(
             name="cstratak-CentOS9-ppc64le",
-            tags=['linux', 'unix', 'rhel', 'ppc64le', 'dtrace'],
+            tags=['linux', 'unix', 'rhel', 'ppc64le'],
             parallel_tests=10,
             timeout_factor=2,  # Increase the timeout on this slow worker
         ),
@@ -176,7 +176,7 @@ def get_workers(settings):
         ),
         cpw(
             name="cstratak-fedora-stable-aarch64",
-            tags=['linux', 'unix', 'fedora', 'arm', 'arm64', 'aarch64', 'dtrace'],
+            tags=['linux', 'unix', 'fedora', 'arm', 'arm64', 'aarch64'],
             parallel_tests=32,
         ),
         cpw(


### PR DESCRIPTION
Four CentOS9 and six Fedora buildbots fail with `test_dtrace` on 3.15 and main:

  * PPC64LE CentOS9 3.15
  * PPC64LE CentOS9 LTO 3.15
  * PPC64LE CentOS9 LTO + PGO 3.15
  * PPC64LE CentOS9 Refleaks 3.15
  * PPC64LE Fedora Stable 3.15
  * PPC64LE Fedora Stable LTO 3.15
  * PPC64LE Fedora Stable LTO + PGO 3.15
  * PPC64LE Fedora Stable Refleaks 3.15
  * PPC64LE Fedora Stable Clang 3.15
  * aarch64 Fedora Stable 3.15

https://buildbot.python.org/#/release_status

9/10 of these are tier 2, so block tomorrow's 3.15 RC2.

Logs contain:
```
'dtrace(1) failed: /usr/bin/dtrace invalid option -q\nUsage /usr/bin/dtrace [--help] [-h | -G] [-C [-I<Path>]] -s File.d [-o <File>]'
```

Affected workers:

* cstratak-CentOS9-ppc64le
* cstratak-fedora-stable-ppc64le
* cstratak-fedora-stable-aarch64

This PR removes the `dtrace` tag from these workers to unblock the release. Passing workers and unstable-tier builds are left as is. The tag can be re-added later.

See also:

* https://github.com/python/buildmaster-config/pull/754 Originally added the tag
* https://github.com/python/cpython/pull/156424 WIP to fix dtrace on CPython side


