### PR TITLE
Kill only the recorded master pid when stopping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,8 @@ SYSTEM_PYTHON=python$(PYTHON_VERSION)
 VENV_DIR=./venv
 REQUIREMENTS=requirements-$(PYTHON_VERSION).txt
 PIP=$(VENV_DIR)/bin/pip
-# make stop-server kills all processes named "python"
-PKILL_NAME="python"
 BUILDBOT=$(VENV_DIR)/bin/buildbot
 VENV_CHECK=$(VENV_DIR)/lib/python$(PYTHON_VERSION)/site-packages/buildbot/master.py
-USER=buildbot
 LOGLINES=50
 
 # Setup targets
@@ -65,18 +62,33 @@ start-master: run-target
 restart-master: TARGET=restart
 restart-master: run-target
 
+# Exits successfully when master/twistd.pid names a running buildbot master.
+PID_IS_MASTER = pid=$$(cat master/twistd.pid 2>/dev/null); \
+	case "$$pid" in \
+		''|*[!0-9]*) false;; \
+		*) ps -o args= -p "$$pid" 2>/dev/null | grep -q buildbot.tac;; \
+	esac
+
 ## stop-master       Stop the buildbot master
-stop-master: TARGET=stop
-stop-master: run-target
-	# issue #384: sometimes when "buildbot stop master" sends SIGINT to
+stop-master: $(VENV_CHECK)
+	# issue #384: sometimes when "buildbot stop master" sends SIGTERM to
 	# Twisted, the server goes in a broken state: it's being "shut down",
 	# but it never completes. The server stays forever in this state: it is
 	# still "running" but no longer schedules new jobs. Kill the process
-	# to make sure that it goes bad to a known state (don't run anymore).
-	echo "Buildbot processes (look for process name: $(PKILL_NAME))"
-	pgrep -u $(USER) $(PKILL_NAME) ||:
-	echo "Send SIGKILL to remaining buildbot processes (if any)"
-	pkill -KILL -u $(USER) $(PKILL_NAME) ||:
+	# to make sure that it goes back to a known state (don't run anymore).
+	# Validate the pid first, since buildbot stop signals it blindly, and
+	# afterwards kill only that pid, not every python process of this user.
+	@if [ -f master/twistd.pid ] && ! { $(PID_IS_MASTER); }; then \
+		echo "Ignoring stale master/twistd.pid: $$pid is not a buildbot master"; \
+		rm -f master/twistd.pid; \
+	fi
+	$(BUILDBOT) stop master; tail -n$(LOGLINES) master/twistd.log
+	@if { $(PID_IS_MASTER); }; then \
+		echo "Sending SIGKILL to remaining buildbot process $$pid"; \
+		kill -KILL "$$pid" ||:; \
+	else \
+		echo "No buildbot master left to kill"; \
+	fi
 
 run-target: $(VENV_CHECK)
 	$(BUILDBOT) $(TARGET) master; tail -n$(LOGLINES) master/twistd.log

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ stop-master: $(VENV_CHECK)
 		rm -f master/twistd.pid; \
 	fi
 	$(BUILDBOT) stop master; tail -n$(LOGLINES) master/twistd.log
+	@echo "Python processes of the buildbot user:"
+	@pgrep -a -u buildbot python ||:
 	@if { $(PID_IS_MASTER); }; then \
 		echo "Sending SIGKILL to remaining buildbot process $$pid"; \
 		kill -KILL "$$pid" ||:; \


### PR DESCRIPTION
The SIGKILL fallback used pkill on every python process of the buildbot user. It now kills the pid in master/twistd.pid, after confirming that process is a buildbot master and before "buildbot stop" can signal it.


The SIGKILL fallback in make stop-master, added for the hang in #384, was pkill -KILL -u buildbot python, which kills every python process the buildbot user owns. It now kills only the pid in master/twistd.pid, after confirming that process is a buildbot master. The check runs before buildbot stop, which signals whatever the file names without looking, so a stale pid file is removed rather than signalled.

Found the issue while working with having a second master on the host.

Tested against a recycled pid (untouched), a hung master (killed), a bystander process (survives), a malformed pid file (ignored) and a healthy master (stops normally).

Related: #384