### PR TITLE
Add master_role to split the web UI off the build engine

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check configuration
-        run: make check PIP=pip BUILDBOT=buildbot PYTHON_VERSION=${{ matrix.python-version }}
+        run: make check check-roles PIP=pip BUILDBOT=buildbot PYTHON=python PYTHON_VERSION=${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PIP=$(VENV_DIR)/bin/pip
 # make stop-server kills all processes named "python"
 PKILL_NAME="python"
 BUILDBOT=$(VENV_DIR)/bin/buildbot
+PYTHON=$(VENV_DIR)/bin/python
 VENV_CHECK=$(VENV_DIR)/lib/python$(PYTHON_VERSION)/site-packages/buildbot/master.py
 USER=buildbot
 LOGLINES=50
@@ -35,11 +36,16 @@ regen-requirements:
 
 # Test targets
 
-.PHONY: check
+.PHONY: check check-roles
 
 ## check             Validate buildbot master configuration
 check: $(VENV_CHECK)
 	$(BUILDBOT) checkconfig master
+
+## check-roles       Validate the configuration in each master_role
+# Unlike `check`, this uses throwaway settings so every role is exercised.
+check-roles: $(VENV_CHECK)
+	$(PYTHON) check_roles.py
 
 # Management targets
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@
 The production server uses /etc/buildbot/settings.yaml configuration file which
 contains secrets like the IRC nickname password.
 
+## Master roles
+
+> [!WARNING]
+> Only the default `all` role is ready for production. The split roles can
+> lose webhooks while the engine is down; do not deploy them yet.
+
+The master can run as one process, or as two masters sharing the database so
+that web traffic and worker traffic stop competing for the same reactor.
+`master_role` in `/etc/buildbot/settings.yaml` selects what a master does:
+
+| `master_role` | Runs | Serves |
+|---|---|---|
+| `all` (default) | workers, builders, schedulers, reporters, janitor | web UI, change hooks, dashboards, force scheduler |
+| `engine` | same as `all`, subject to `run_janitor` and `run_reporters` | nothing |
+| `ui` | nothing | same as `all` |
+
+`engine` and `ui` need a WAMP router such as [crossbar](https://crossbar.io/),
+reachable only from the host:
+
+    master_role: engine        # or: ui
+    mq_router_url: ws://localhost:1245/ws
+    mq_realm: buildbot         # optional
+    mq_debug_level: error      # none, critical, error, warn, info, debug, trace
+
+Reporters must run on exactly one master, so set `run_reporters: false` on
+every engine but one. The janitor may run anywhere; `run_janitor: false` only
+keeps it off a master. Both must be real YAML booleans.
+
+Changing `master_role` or any `mq_*` setting needs a restart, not a reconfig.
+`make update-master` does that.
+
 ## Update requirements
 
 Run locally:
@@ -124,3 +155,62 @@ Finally, the master can be stopped when no longer needed by running
 ```
 make stop-master
 ```
+
+### Testing a multi-master split locally
+
+This needs a WAMP router and a database both masters can share. Install
+[crossbar](https://crossbar.io/) in its own virtualenv, write a router config
+from the [buildbot MQ documentation](https://docs.buildbot.net/current/manual/configuration/global.html)
+bound to `127.0.0.1`, and start it:
+
+```bash
+python3 -m venv /tmp/crossbar-venv
+/tmp/crossbar-venv/bin/pip install crossbar
+/tmp/crossbar-venv/bin/crossbar start --cbdir /tmp/cbdir
+```
+
+Start a throwaway PostgreSQL (`psycopg2` needs `libpq-dev`; `psycopg2-binary`
+works for local testing):
+
+```bash
+podman run -d --name bb-test -p 127.0.0.1:15432:5432 \
+    -e POSTGRES_PASSWORD=bb -e POSTGRES_USER=bb -e POSTGRES_DB=bb \
+    docker.io/library/postgres:17-alpine
+```
+
+Give each master a basedir sharing this repository's config:
+
+```bash
+for role in engine ui; do
+    mkdir -p /tmp/bb-$role
+    cp master/buildbot.tac /tmp/bb-$role/
+    ln -sfn $(pwd)/master/master.cfg /tmp/bb-$role/master.cfg
+    ln -sfn $(pwd)/master/custom     /tmp/bb-$role/custom
+done
+```
+
+Write one settings file per role, differing only in `master_role` and
+`web_port` (`ui` only). Point `git_url` at a small local repository as a plain
+path, so builds fail fast and reporters skip GitHub:
+
+```yaml
+master_role: engine
+db_url: postgresql+psycopg2://bb:bb@127.0.0.1:15432/bb
+mq_router_url: ws://127.0.0.1:1245/ws
+use_local_worker: true
+git_url: /path/to/a/small/throwaway/git/repo
+web_port: 8010
+buildbot_url: http://127.0.0.1:8010/
+```
+
+Then:
+
+```bash
+export PYBUILDBOT_SETTINGS_PATH=/path/to/settings-engine.yaml
+./venv/bin/buildbot upgrade-master /tmp/bb-engine
+./venv/bin/buildbot start /tmp/bb-engine
+PYBUILDBOT_SETTINGS_PATH=/path/to/settings-ui.yaml ./venv/bin/buildbot start /tmp/bb-ui
+```
+
+Both logs should report `Wamp connection succeed!`. Force a build from the UI
+master and check that the engine runs it.

--- a/check_roles.py
+++ b/check_roles.py
@@ -1,0 +1,196 @@
+"""Assert what each master_role configures.
+
+checkconfig alone is not enough: buildbot drops several consistency checks
+once multiMaster is set, so a misplaced web server would still parse cleanly.
+"""
+
+import os
+import sys
+import tempfile
+
+from buildbot.config.errors import ConfigErrors
+from buildbot.config.master import FileLoader
+
+BASEDIR = "master"
+ROUTER = "ws://127.0.0.1:1245/ws"
+
+# The janitor contributes schedulers of its own; everything else is ours.
+JANITOR_SCHEDULERS = {"__Janitor", "__Janitor_force"}
+
+# What each role must and must not configure.
+EXPECTED = {
+    "all": {
+        "workers": True, "builders": True, "force scheduler": True,
+        "worker port": True, "web server": True, "change hook": True,
+        "dashboards": True, "reporters": True, "janitor": True,
+        "multiMaster": False, "mq": "simple", "mq realm": None,
+        "mq debug level": None,
+    },
+    "engine": {
+        "workers": True, "builders": True, "force scheduler": False,
+        "worker port": True, "web server": False, "change hook": False,
+        "dashboards": False, "reporters": True, "janitor": True,
+        "multiMaster": True, "mq": "wamp", "mq realm": "buildbot",
+        "mq debug level": "error",
+    },
+    "ui": {
+        "workers": False, "builders": False, "force scheduler": True,
+        "worker port": False, "web server": True, "change hook": True,
+        "dashboards": True, "reporters": False, "janitor": False,
+        "multiMaster": True, "mq": "wamp", "mq realm": "buildbot",
+        "mq debug level": "error",
+    },
+}
+
+# Far below the real fleet, but catches a configuration that came out empty.
+MIN_BUILDERS = 100
+MIN_WORKERS = 20
+
+
+def load(settings):
+    """Load master.cfg with the given settings file contents."""
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as f:
+        f.write(settings)
+        f.flush()
+        os.environ["PYBUILDBOT_SETTINGS_PATH"] = f.name
+        return FileLoader(BASEDIR, "master.cfg").loadConfig()
+
+
+def role_settings(role, extra=""):
+    router = "" if role == "all" else f"mq_router_url: {ROUTER}\n"
+    return f"master_role: {role}\n{router}{extra}"
+
+
+def actual(config):
+    # configurators are not kept on the loaded config: detect the janitor by
+    # its schedulers instead
+    names = set(config.schedulers)
+    return {
+        "workers": bool(config.workers),
+        "builders": bool(config.builders),
+        "force scheduler": "force" in names,
+        "worker port": bool(config.protocols.get("pb")),
+        "web server": bool(config.www.get("port")),
+        # a web server with no hook or no dashboards is not the one we want
+        "change hook": bool(config.www.get("change_hook_dialects")),
+        "dashboards": "wsgi_dashboards" in config.www.get("plugins", {}),
+        "reporters": bool(config.services),
+        "janitor": "__Janitor" in names,
+        "multiMaster": bool(config.multiMaster),
+        "mq": config.mq.get("type", "simple"),
+        "mq realm": config.mq.get("realm"),
+        "mq debug level": config.mq.get("wamp_debug_level"),
+    }
+
+
+def force_builders(config):
+    scheduler = config.schedulers.get("force")
+    return set(scheduler.builderNames) if scheduler else set()
+
+
+def check_invariants(role, config, fail):
+    """Guard against a role that is shaped right but empty."""
+    names = set(config.schedulers)
+    branch_schedulers = names - {"force"} - JANITOR_SCHEDULERS
+
+    # Encodes the current placement, branch schedulers on the engine. That is
+    # under review (webhook-loss gap); swap these if the schedulers move.
+    if role in ("all", "engine"):
+        if len(config.builders) < MIN_BUILDERS:
+            fail(f"{role}: only {len(config.builders)} builders")
+        if len(config.workers) < MIN_WORKERS:
+            fail(f"{role}: only {len(config.workers)} workers")
+        if not branch_schedulers:
+            fail(f"{role}: no branch schedulers")
+    elif branch_schedulers:
+        fail(f"{role}: unexpected branch schedulers {sorted(branch_schedulers)}")
+
+    # The force scheduler must offer exactly the configured builders; the
+    # janitor adds its own builder after master.cfg has run.
+    if role == "all":
+        configured = {b.name for b in config.builders} - {"__Janitor"}
+        if force_builders(config) != configured:
+            missing = configured - force_builders(config)
+            extra = force_builders(config) - configured
+            fail(f"{role}: force scheduler builders differ, "
+                 f"missing {sorted(missing)[:3]}, unexpected {sorted(extra)[:3]}")
+
+
+def expect_rejected(label, settings, reason, fail):
+    try:
+        load(settings)
+    except ConfigErrors as error:
+        if reason in str(error):
+            print(f"==> {label} is rejected")
+        else:
+            fail(f"{label} failed, but not for the expected reason: {error}")
+    else:
+        fail(f"{label} was accepted")
+
+
+def main():
+    failures = []
+    fail = failures.append
+
+    offered = {}
+    for role, expected in EXPECTED.items():
+        config = load(role_settings(role))
+        got = actual(config)
+        for key, want in expected.items():
+            if got[key] != want:
+                fail(f"{role}: expected {key}={want!r}, got {got[key]!r}")
+        check_invariants(role, config, fail)
+        offered[role] = force_builders(config)
+        print(f"==> {role}: " + ", ".join(f"{k}={got[k]}" for k in expected))
+
+    # The ui configures no builders, but must still offer the same set as all.
+    if offered["ui"] != offered["all"]:
+        missing = offered["all"] - offered["ui"]
+        extra = offered["ui"] - offered["all"]
+        fail(f"ui force scheduler differs from all: "
+             f"missing {sorted(missing)[:3]}, unexpected {sorted(extra)[:3]}")
+    else:
+        print(f"==> ui offers the same {len(offered['ui'])} builders as all")
+
+    # The two singleton switches must each turn off one thing and only that.
+    for flag, key in (("run_reporters", "reporters"), ("run_janitor", "janitor")):
+        got = actual(load(role_settings("engine", f"{flag}: false\n")))
+        other = "janitor" if key == "reporters" else "reporters"
+        if got[key]:
+            fail(f"engine with {flag}: false still has {key}")
+        if not got[other]:
+            fail(f"engine with {flag}: false also lost {other}")
+        print(f"==> engine with {flag}: false drops {key}, keeps {other}")
+
+    # use_local_worker must fall back to UnixBuild with no explicit factory.
+    if not load(role_settings("engine", "use_local_worker: true\n")).builders:
+        fail("use_local_worker without local_worker_buildfactory built no builders")
+    else:
+        print("==> use_local_worker without an explicit factory loads")
+
+    expect_rejected("an unknown master_role", "master_role: nonsense\n",
+                    "must be 'all', 'engine' or 'ui'", fail)
+    for role in ("engine", "ui"):
+        expect_rejected(f"{role} without mq_router_url", f"master_role: {role}\n",
+                        "requires mq_router_url", fail)
+    for flag in ("run_reporters", "run_janitor"):
+        expect_rejected(f"a quoted boolean for {flag}",
+                        role_settings("ui", f'{flag}: "false"\n'),
+                        "must be true or false", fail)
+    expect_rejected("a non-string mq_realm", role_settings("engine", "mq_realm: true\n"),
+                    "must be a string", fail)
+    expect_rejected("an unknown mq_debug_level",
+                    role_settings("engine", "mq_debug_level: chatty\n"),
+                    "must be one of", fail)
+
+    if failures:
+        print("\nFAILED:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    print("\n==> all roles OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/master/custom/builders.py
+++ b/master/custom/builders.py
@@ -510,9 +510,8 @@ BUILDER_DEFS.extend(generate_builderdefs({UNSTABLE}, [
 def get_builder_defs(settings):
     # Override with a simple default if we are using local workers
     if settings.use_local_worker:
-        local_buildfactory = getattr(
-            factories, settings.local_worker_buildfactory, UnixBuild
-        )
+        factory_name = settings.get("local_worker_buildfactory", "UnixBuild")
+        local_buildfactory = getattr(factories, factory_name, UnixBuild)
         return [BuilderDef(
             "Test Builder",
             local_buildfactory,

--- a/master/custom/workers.py
+++ b/master/custom/workers.py
@@ -40,6 +40,7 @@ class CPythonWorker:
         exclude_test_resources=None,
         downtime=None,
         git_options=None,
+        create_bb_worker=True,
     ):
         self.name = name
         self.tags = tags or set()
@@ -53,6 +54,11 @@ class CPythonWorker:
         for branch in branches:
             if isinstance(branch, str):
                 raise TypeError('use BRANCHES for branch filtering')
+
+        if not create_bb_worker:
+            # No builds run here, so no buildbot Worker objects are needed.
+            self.bb_worker = None
+            return
 
         worker_settings = settings.workers[name]
         owner = name.split("-")[0]
@@ -88,8 +94,8 @@ itamaro_downtime = no_builds_between(
     tz=ZoneInfo("America/Los_Angeles"),
 )
 
-def get_workers(settings):
-    cpw = partial(CPythonWorker, settings)
+def get_workers(settings, create_bb_workers=True):
+    cpw = partial(CPythonWorker, settings, create_bb_worker=create_bb_workers)
     if settings.use_local_worker:
         return [cpw(name="local-worker")]
     return [

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -86,10 +86,39 @@ except FileNotFoundError:
     settings = Settings()
 
 
-WORKERS = get_workers(settings)
-workers_by_name = {w.name: w for w in WORKERS}
+# Accepted by autobahn, per the buildbot MQ documentation.
+MQ_DEBUG_LEVELS = ("none", "critical", "error", "warn", "info", "debug", "trace")
 
-AUTH, AUTHZ = set_up_authorization(settings)
+# "all", "engine" or "ui"; see "Master roles" in README.md.
+MASTER_ROLE = settings.get("master_role", "all")
+if MASTER_ROLE not in ("all", "engine", "ui"):
+    raise ValueError(
+        f"master_role must be 'all', 'engine' or 'ui', got {MASTER_ROLE!r}"
+    )
+
+RUN_BUILDS = MASTER_ROLE in ("all", "engine")
+SERVE_WEB = MASTER_ROLE in ("all", "ui")
+
+
+def bool_setting(name, default):
+    value = settings.get(name, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be true or false, got {value!r}")
+    return value
+
+
+def str_setting(name, default):
+    value = settings.get(name, default)
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string, got {value!r}")
+    return value
+
+
+RUN_REPORTERS = bool_setting("run_reporters", True) and RUN_BUILDS
+RUN_JANITOR = bool_setting("run_janitor", True) and RUN_BUILDS
+
+WORKERS = get_workers(settings, create_bb_workers=RUN_BUILDS)
+workers_by_name = {w.name: w for w in WORKERS}
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -97,15 +126,33 @@ c = BuildmasterConfig = {}
 
 c["db_url"] = str(settings.db_url)
 
-# configure a janitor which will delete all logs older than 6 months,
-# and will run on sundays at noon
-c["configurators"] = [
-    util.JanitorConfigurator(
-        logHorizon=timedelta(days=180),
-        hour=12,
-        dayOfWeek=6,
-    )
-]
+if MASTER_ROLE != "all":
+    if not settings.get("mq_router_url", None):
+        raise ValueError(f"master_role {MASTER_ROLE!r} requires mq_router_url")
+    debug_level = str_setting("mq_debug_level", "error")
+    if debug_level not in MQ_DEBUG_LEVELS:
+        raise ValueError(
+            f"mq_debug_level must be one of {', '.join(MQ_DEBUG_LEVELS)},"
+            f" got {debug_level!r}"
+        )
+    c["multiMaster"] = True
+    c["mq"] = {
+        "type": "wamp",
+        "router_url": str_setting("mq_router_url", None),
+        "realm": str_setting("mq_realm", "buildbot"),
+        "wamp_debug_level": debug_level,
+    }
+
+if RUN_JANITOR:
+    # configure a janitor which will delete all logs older than 6 months,
+    # and will run on sundays at noon
+    c["configurators"] = [
+        util.JanitorConfigurator(
+            logHorizon=timedelta(days=180),
+            hour=12,
+            dayOfWeek=6,
+        )
+    ]
 
 # Note: these cache values are not currently tuned in any meaningful way.
 # Some are taken straight from the buildbot docs at
@@ -124,7 +171,8 @@ c["caches"] = {
 }
 
 # workers are set up in workers.py
-c["workers"] = [w.bb_worker for w in WORKERS]
+if RUN_BUILDS:
+    c["workers"] = [w.bb_worker for w in WORKERS]
 
 # git_branches used to be here; moved to branches.py
 
@@ -312,147 +360,158 @@ assert all_pull_request_builders
 
 # Set up aditional schedulers
 
-c["schedulers"].append(
-    schedulers.ForceScheduler(
-        name="force",
-        builderNames=[builder.name for builder in c["builders"]],
-        reason=util.FixedParameter(name="reason", label="reason", default=""),
-        codebases=[
-            util.CodebaseParameter(
-                "",
-                label="CPython repository",
-                # will generate nothing in the form, but branch, revision, repository,
-                # and project are needed by buildbot scheduling system so we
-                # need to pass a value ("")
-                branch=util.FixedParameter(name="branch", default=""),
-                revision=util.FixedParameter(name="revision", default=""),
-                repository=util.FixedParameter(name="repository", default=""),
-                project=util.FixedParameter(name="project", default=""),
-            ),
-        ],
+all_builder_names = [builder.name for builder in c["builders"]]
+
+if not RUN_BUILDS:
+    # No workers on this master, so no builders or branch schedulers either.
+    c["builders"] = []
+    c["schedulers"] = []
+
+if SERVE_WEB:
+    c["schedulers"].append(
+        schedulers.ForceScheduler(
+            name="force",
+            builderNames=all_builder_names,
+            reason=util.FixedParameter(name="reason", label="reason", default=""),
+            codebases=[
+                util.CodebaseParameter(
+                    "",
+                    label="CPython repository",
+                    # will generate nothing in the form, but branch, revision, repository,
+                    # and project are needed by buildbot scheduling system so we
+                    # need to pass a value ("")
+                    branch=util.FixedParameter(name="branch", default=""),
+                    revision=util.FixedParameter(name="revision", default=""),
+                    repository=util.FixedParameter(name="repository", default=""),
+                    project=util.FixedParameter(name="project", default=""),
+                ),
+            ],
+        )
     )
-)
 
 # 'workerPortnum' defines the TCP port to listen on. This must match the value
 # configured into the buildworkers (with their --master option)
 
-c["protocols"] = {"pb": {"port": "tcp:{}".format(settings.worker_port)}}
+if RUN_BUILDS:
+    c["protocols"] = {"pb": {"port": "tcp:{}".format(settings.worker_port)}}
 
 # 'www' is the configuration for everything accessible via
 # http[s]://buildbot.python.org/all/
 
-c["www"] = dict(
-    port=f"tcp:{int(settings.web_port)}",
-    auth=AUTH,
-    authz=AUTHZ,
-    change_hook_dialects={
-        "github": {
-            "class": partial(
-                CustomGitHubEventHandler,
-                builder_names=all_pull_request_builders,
-            ),
-            "secret": str(settings.github_change_hook_secret),
-            "strict": True,
-            "token": settings.github_status_token,
+if SERVE_WEB:
+    AUTH, AUTHZ = set_up_authorization(settings)
+    c["www"] = dict(
+        port=f"tcp:{int(settings.web_port)}",
+        auth=AUTH,
+        authz=AUTHZ,
+        change_hook_dialects={
+            "github": {
+                "class": partial(
+                    CustomGitHubEventHandler,
+                    builder_names=all_pull_request_builders,
+                ),
+                "secret": str(settings.github_change_hook_secret),
+                "strict": True,
+                "token": settings.github_status_token,
+            },
         },
-    },
-    plugins=dict(waterfall_view={}, console_view={}, grid_view={}),
-    avatar_methods=[util.AvatarGitHub(token=settings.github_status_token)],
-    ws_ping_interval=30,
-)
+        plugins=dict(waterfall_view={}, console_view={}, grid_view={}),
+        avatar_methods=[util.AvatarGitHub(token=settings.github_status_token)],
+        ws_ping_interval=30,
+    )
 
 # 'services' is a list of Status Targets. The results of each build will be
 # pushed to these targets. buildbot/reporters/*.py has a variety to choose from,
 # including web pages, email senders, and IRC bots.
 
-c["services"] = []
+if RUN_REPORTERS:
+    c["services"] = []
 
+    status_email = str(settings.status_email)
+    if bool(settings.send_mail):
+        c["services"].append(
+            reporters.MailNotifier(
+                generators=[
+                    reporters.BuildSetStatusGenerator(
+                        mode='problem',
+                        builders=mail_status_builders,
+                        message_formatter=MESSAGE_FORMATTER,
+                    ),
+                    reporters.WorkerMissingGenerator(workers='all'),
+                ],
+                fromaddr=str(settings.from_email),
+                relayhost=str(settings.email_relay_host),
+                extraRecipients=[status_email],
+                sendToInterestedUsers=False,
+                extraHeaders={"Reply-To": status_email},
+            )
+        )
 
-status_email = str(settings.status_email)
-if bool(settings.send_mail):
-    c["services"].append(
-        reporters.MailNotifier(
-            generators=[
-                reporters.BuildSetStatusGenerator(
-                    mode='problem',
-                    builders=mail_status_builders,
-                    message_formatter=MESSAGE_FORMATTER,
+    if bool(settings.irc_notice):
+        irc_args = dict(
+            host=str(settings.irc_host),
+            nick=str(settings.irc_nick),
+            channels=[dict(channel=str(settings.irc_channel))],
+            notify_events=set(
+                settings.get(
+                    'irc_notify_events',
+                    # 'cancelled' is not logged to avoid spaming IRC when
+                    # a "pull-request-scheduler" is cancelled
+                    ['better', 'worse', 'exception']
+                    )
                 ),
-                reporters.WorkerMissingGenerator(workers='all'),
+            useColors=True,
+            )
+        password = settings.get('irc_password', None)
+        if password:
+            irc_args['useSASL'] = True
+            irc_args['password'] = password
+        c["services"].append(reporters.IRC(**irc_args))
+
+    c["services"].append(
+        reporters.GitHubStatusPush(
+            str(settings.github_status_token),
+            generators=[
+                reporters.BuildStartEndStatusGenerator(
+                    builders=github_status_builders + all_pull_request_builders,
+                ),
             ],
-            fromaddr=str(settings.from_email),
-            relayhost=str(settings.email_relay_host),
-            extraRecipients=[status_email],
-            sendToInterestedUsers=False,
-            extraHeaders={"Reply-To": status_email},
+            verbose=bool(settings.verbosity),
         )
     )
 
-if bool(settings.irc_notice):
-    irc_args = dict(
-        host=str(settings.irc_host),
-        nick=str(settings.irc_nick),
-        channels=[dict(channel=str(settings.irc_channel))],
-        notify_events=set(
-            settings.get(
-                'irc_notify_events',
-                # 'cancelled' is not logged to avoid spaming IRC when
-                # a "pull-request-scheduler" is cancelled
-                ['better', 'worse', 'exception']
-                )
-            ),
-        useColors=True,
+    start_formatter = reporters.MessageFormatterRenderable('Build started.')
+    end_formatter = reporters.MessageFormatterRenderable('Build done.')
+    pending_formatter = reporters.MessageFormatterRenderable('Build pending.')
+    c["services"].append(
+        GitHubPullRequestReporter(
+            str(settings.github_status_token),
+            generators=[
+                reporters.BuildRequestGenerator(formatter=pending_formatter),
+                reporters.BuildStartEndStatusGenerator(
+                    builders=github_status_builders,
+                    start_formatter=start_formatter,
+                    end_formatter=end_formatter,
+                ),
+            ],
+            verbose=bool(settings.verbosity),
         )
-    password = settings.get('irc_password', None)
-    if password:
-        irc_args['useSASL'] = True
-        irc_args['password'] = password
-    c["services"].append(reporters.IRC(**irc_args))
-
-c["services"].append(
-    reporters.GitHubStatusPush(
-        str(settings.github_status_token),
-        generators=[
-            reporters.BuildStartEndStatusGenerator(
-                builders=github_status_builders + all_pull_request_builders,
-            ),
-        ],
-        verbose=bool(settings.verbosity),
     )
-)
 
-start_formatter = reporters.MessageFormatterRenderable('Build started.')
-end_formatter = reporters.MessageFormatterRenderable('Build done.')
-pending_formatter = reporters.MessageFormatterRenderable('Build pending.')
-c["services"].append(
-    GitHubPullRequestReporter(
-        str(settings.github_status_token),
-        generators=[
-            reporters.BuildRequestGenerator(formatter=pending_formatter),
-            reporters.BuildStartEndStatusGenerator(
-                builders=github_status_builders,
-                start_formatter=start_formatter,
-                end_formatter=end_formatter,
-            ),
-        ],
-        verbose=bool(settings.verbosity),
+    c["services"].append(
+        DiscordReporter(
+            str(settings.discord_webhook),
+            generators=[
+                reporters.BuildRequestGenerator(formatter=pending_formatter),
+                reporters.BuildStartEndStatusGenerator(
+                    builders=github_status_builders,
+                    start_formatter=start_formatter,
+                    end_formatter=end_formatter,
+                ),
+            ],
+            verbose=bool(settings.verbosity),
+        )
     )
-)
-
-c["services"].append(
-    DiscordReporter(
-        str(settings.discord_webhook),
-        generators=[
-            reporters.BuildRequestGenerator(formatter=pending_formatter),
-            reporters.BuildStartEndStatusGenerator(
-                builders=github_status_builders,
-                start_formatter=start_formatter,
-                end_formatter=end_formatter,
-            ),
-        ],
-        verbose=bool(settings.verbosity),
-    )
-)
 
 
 # if you set 'manhole', you can telnet into the buildmaster and get an
@@ -482,14 +541,15 @@ c["buildbotNetUsageData"] = None
 
 c['change_source'] = []
 
-c['www']['plugins']['wsgi_dashboards'] = [
-    {
-        'name': 'release_status',
-        'caption': 'Release Status',
-        'app': get_release_status_app(
-            release_status_builders,
-            test_result_dir='/data/www/buildbot/test-results/'),
-        'order': 2,
-        'icon': 'rocket'
-    }
-]
+if SERVE_WEB:
+    c['www']['plugins']['wsgi_dashboards'] = [
+        {
+            'name': 'release_status',
+            'caption': 'Release Status',
+            'app': get_release_status_app(
+                release_status_builders,
+                test_result_dir='/data/www/buildbot/test-results/'),
+            'order': 2,
+            'icon': 'rocket'
+        }
+    ]


### PR DESCRIPTION
Adds master_role so the web UI and the build engine can run as separate masters sharing the database, per #785 . The default, all, is today's single process and matches main over everything, so merging changes nothing until a role is set in settings.yaml.

engine runs workers, builders, schedulers, reporters and the janitor. ui runs the web server, change hooks, dashboards and the force scheduler. Both need a WAMP router. run_reporters must be false on all but one engine, since reporters are not clustered and would duplicate notifications. run_janitor is only an opt-out.

check_roles.py runs in CI and asserts what each role does and does not configure, since checkconfig drops those checks once multiMaster is set.

Only `all` is ready for production. The split has the webhook gap described in #785.

Disclosure: The PR, investigating the issue and the codebases, drafting the code and tests and running local instances to verify things work as intended has been assisted by various models, notably Fable 5.1, Claude 4.8 and gpt 5.6 sol.